### PR TITLE
Add in timestamping for usability

### DIFF
--- a/socketcan_adapter/include/socketcan_adapter/can_frame.hpp
+++ b/socketcan_adapter/include/socketcan_adapter/can_frame.hpp
@@ -18,6 +18,7 @@
 #include <linux/can.h>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -62,7 +63,7 @@ public:
   CanFrame(
     const canid_t raw_id,
     const std::array<unsigned char, CAN_MAX_DLC> & data,
-    const uint64_t & timestamp,
+    const uint64_t & bus_timestamp,
     uint8_t len = CAN_MAX_DLC);
 
   /// @brief Initialize CanFrame with a partial ID and data defined in std::array
@@ -74,7 +75,7 @@ public:
   CanFrame(
     const canid_t id,
     const std::array<unsigned char, CAN_MAX_DLC> & data,
-    const uint64_t & timestamp,
+    const uint64_t & bus_timestamp,
     FrameType & frame_type,
     IdType & frame_id_type,
     uint8_t len = CAN_MAX_DLC);
@@ -113,9 +114,29 @@ public:
   /// @param data INPUT raw data to pass through the socket
   void set_data(const std::array<unsigned char, CAN_MAX_DLC> & data);
 
-  /// @brief Set timestamp
+  /// @brief Set bus timestamp
   /// @param timestamp INPUT time as uint64_t from the bus
-  void set_timestamp(const uint64_t & timestamp);
+  void set_bus_timestamp(const uint64_t & timestamp);
+
+  /// @brief Set receive timestamp
+  /// @param timestamp INPUT time as uint64_t from the bus
+  void set_receive_timestamp(const uint64_t & timestamp);
+
+  /// @brief Set timestamp
+  /// @param timestamp INPUT time as std::chrono::system_clock::time_point from the bus
+  void set_bus_timestamp(const std::chrono::system_clock::time_point & timestamp);
+
+  /// @brief Set timestamp
+  /// @param timestamp INPUT time as std::chrono::steady_clock::time_point from the adapter
+  void set_receive_timestamp(const std::chrono::steady_clock::time_point & timestamp);
+
+  /// @brief Get bus time
+  /// @return returns std::chrono::system_clock::time_point for when the frame was received on the bus
+  std::chrono::system_clock::time_point get_bus_time() const;
+
+  /// @brief Get receive time
+  /// @return returns std::chrono::steady_clock::time_point for when the frame was received by the adapter
+  std::chrono::steady_clock::time_point get_receive_time() const;
 
   /// @brief Get frame type
   /// @return returns polymath::socketcan::FrameType
@@ -156,7 +177,8 @@ public:
 
 private:
   struct can_frame frame_{};
-  uint64_t timestamp_{};
+  std::chrono::steady_clock::time_point receive_time_{};
+  std::chrono::system_clock::time_point bus_time_{};
 };
 
 }  // namespace polymath::socketcan

--- a/socketcan_adapter/src/socketcan_adapter.cpp
+++ b/socketcan_adapter/src/socketcan_adapter.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <future>
 #include <memory>
@@ -172,9 +173,12 @@ std::optional<SocketcanAdapter::socket_error_string_t> SocketcanAdapter::receive
     struct timeval tv;
     ioctl(socket_file_descriptor_, SIOCGSTAMP, &tv);
 
-    uint64_t timestamp_uint64 = static_cast<uint64_t>(tv.tv_sec) * 1e6 + tv.tv_usec;
+    // uint64_t timestamp_uint64 = static_cast<uint64_t>(tv.tv_sec) * 1e6 + tv.tv_usec;
+    std::chrono::system_clock::time_point timestamp{
+      std::chrono::seconds{tv.tv_sec} + std::chrono::microseconds{tv.tv_usec}};
     polymath_can_frame.set_frame(frame);
-    polymath_can_frame.set_timestamp(timestamp_uint64);
+    polymath_can_frame.set_bus_timestamp(timestamp);
+    polymath_can_frame.set_receive_timestamp(std::chrono::steady_clock::now());
   }
 
   return error_string.empty() ? std::nullopt : std::optional<socket_error_string_t>(error_string);


### PR DESCRIPTION
# Add in timestamping for usability

We want the socketcan adapter system to be able to record timestamps into the can frames so that the user can reference it when evaluating data. The user can also record said timestamp to measure things like frequency or discrepancies in expectations.

To enable this we are making the following changes
## Can Frame
-  Add storage for BUS TIME which is tied to system clock and RECEIVE TIME which we tie to steady clock. This way we have two references for when a can frame is received
- Add the missing getter for the timestamps, and add getters for both types in case the caller is using one or the other
- Switch from uint64_t to utilizing std::chrono to align with C++ standard

## Socketcan Adapter
- Store the bus time and receive time when receiving a CAN message as the appropriate type