### PR TITLE
Result should only show when we FAIL

### DIFF
--- a/CLAUDE_PLAN_AND_RESOLUTIONS.md
+++ b/CLAUDE_PLAN_AND_RESOLUTIONS.md
@@ -1,0 +1,113 @@
+# Axiomatic Adapter — Plan & Resolutions
+
+This document captures the design plan and the resolution status of every issue identified during the Axiomatic adapter audit. It mirrors the working plan used while implementing the fixes on branch `zeerek/bugfix-axiomatic-flips-error-logic`.
+
+---
+
+## Context
+
+The Axiomatic CAN-to-Ethernet adapter ([axiomatic_adapter/](axiomatic_adapter/)) is the TCP-over-Ethernet alternative to a Kvaser SocketCAN device. ECU flashing through it failed intermittently, while flashing via Kvaser was reliable. Two audit passes pinned the asymmetry to the TCP transport layer: the adapter treated the byte stream as one-CAN-frame-per-read and only understood the deprecated "CAN Stream" message type. Under the bursty traffic of a flash protocol, this dropped frames three different ways.
+
+The work was staged into three phases so the flash bench could validate intermediate progress.
+
+---
+
+## Audit findings — status table
+
+| # | Severity | Finding | Resolved in |
+|---|----------|---------|-------------|
+| 1 | CRITICAL | `send()` wrote 8 data bytes regardless of DLC; declared `message_length` disagreed with actual payload | Phase 1 |
+| 2 | CRITICAL | No TCP stream framing — coalesced or split CAN frames were silently dropped | Phase 1 (partial) → Phase 2 (complete) |
+| 3 | CRITICAL | Heartbeat (Message ID 4, every 1 s) and Status Response (ID 3) were rejected as garbage, corrupting stream alignment | Phase 2 |
+| 4 | CRITICAL | The protocol's Message Data Length at bytes 9-10 was ignored; framing was guessed from the control byte | Phase 2 |
+| 5 | CRITICAL | A single protocol message can carry multiple CAN + Notification frames; only the first was delivered | Phase 2 |
+| 6 | CRITICAL | Bridge error callbacks had inverted logic + UB dereference of an empty `std::optional` | Already fixed in tree prior to this branch (verified) |
+| 7 | HIGH | No `TCP_NODELAY` — Nagle's algorithm added up to ~40 ms latency per small write | Phase 3 |
+| 8 | HIGH | Synchronous `boost::asio::write()` from the bridge thread raced `async_receive` on the same socket | Phase 3 |
+
+---
+
+## Phase 1 — Quick correctness fixes (DONE)
+
+Goal: ship the smallest changes that make the wire protocol behave so the flash bench could validate immediately.
+
+- **`send()` DLC fix.** `send()` now writes exactly `frame_data_length` bytes after the header instead of all 8 of `frame.get_data()`. The declared `message_length` and the actual payload bytes finally match.
+- **First-cut TCP framer.** Added `AxiomaticFrameParser` with a persistent `std::vector<uint8_t>` buffer. The parser scans for a sync header, decodes a complete frame, leaves trailing partial bytes for the next read, and skips garbage prefixes.
+- **`receive()` rewired** to drain the parser before doing any I/O and to append fresh bytes after a successful read. Coalesced frames now deliver back-to-back without additional `async_receive` calls.
+- **`INCOMPLETE_FRAME_SENTINEL`** suppresses the "bytes arrived but not yet a full frame" case from the reception loop's `error_callback_`.
+- **Stale test NOTE removed** — the "first message may fail" comment was a symptom of the absent framer.
+
+Tests: 11 parser unit tests + 4 loopback send-length tests, no hardware required.
+
+### Phase 1 gap that motivated Phase 2
+
+The Phase 1 parser hard-coded a **7-byte** "sync header" including `0x01` as the last byte. That `0x01` is actually the first byte of the Message ID — specifically Message ID 1, "deprecated CAN Stream." The protocol also defines Message IDs 3 (Status Response), 4 (Heartbeat), and 5 (CAN FD Stream), all of which share the first **6** bytes but differ at bytes 6-7. The Phase 1 parser:
+
+- Rejected heartbeats as garbage, dropping their bytes and risking mid-message desync.
+- Computed total frame size from the control byte (only meaningful for CAN Stream messages), with no way to skip other message types cleanly.
+- Returned only one CAN frame per protocol message, while the spec allows multiple CAN + Notification frames packed together.
+
+---
+
+## Phase 2 — Protocol-correct streaming parser (DONE)
+
+Goal: make the parser understand the actual Axiomatic message envelope, not just a sync prefix.
+
+- **`SYNC_PREFIX` is now 6 bytes** (`AXIO` + `0xBA 0x36`). Message ID lives at bytes 6-7 and is treated as data, not header.
+- **Framing uses the protocol's Message Data Length field** (bytes 9-10). Total message size is `11 + data_length`. The parser waits for that many bytes before consuming anything.
+- **Message ID dispatch.** CAN Stream messages (ID 1) are decoded; Heartbeat (ID 4), Status Response (ID 3), CAN FD Stream (ID 5), and any unknown ID are consumed and counted, never surfaced as errors.
+- **Multi-frame iteration.** `decodeCanStreamBody()` walks the CAN Stream payload one control byte at a time, handling CAN frames (control bit 7 = 0) and skipping Notification frames (bit 7 = 1, fixed 5 bytes). Decoded CAN frames flow through an internal `std::deque` so the existing one-frame-per-call API still works.
+- **Diagnostic counters** added: `heartbeats_seen`, `status_responses_seen`, `can_fd_messages_skipped`, `unknown_messages_skipped`, `notification_frames_skipped`, `dropped_bytes`.
+- **Verbose mode.** `AxiomaticFrameParser::set_verbose(true)` prints one `std::cout` line per non-CAN event. Plumbed all the way through: `ros2 run axiomatic_adapter axiomatic_socketcan_bridge ... -v` now flips parser verbosity too.
+- **`send()` wire layout unchanged**, but the source now references `SYNC_PREFIX` + `MSG_ID_CAN_STREAM_DEPRECATED` explicitly so the intent is obvious.
+
+Tests: parser tests refactored around a `encodeCanStreamMessage` / `encodeHeartbeatMessage` / etc. helper set, plus new cases for packed multi-frame messages, mixed CAN+Notification bodies, heartbeats coalesced with CAN traffic, status responses, FD frames, and split-across-append scenarios.
+
+---
+
+## Phase 3 — Concurrency & throughput (DONE)
+
+Goal: eliminate the remaining intermittent failure classes — Nagle-induced latency and the unsynchronized cross-thread socket access.
+
+- **TCP_NODELAY** is set immediately after a successful connect. Failure is logged but non-fatal.
+- **Persistent `io_context`** runs on a dedicated worker thread for the adapter's lifetime, held alive by an `executor_work_guard`. The per-call `restart()`/`run()` pattern is gone.
+- **`boost::asio::strand`** serializes every socket operation. `send()` and `receive()` post async work onto the strand and block the calling thread on a `std::promise`/`std::future` — public sync signatures unchanged, so the bridge keeps working as-is.
+- **Reception loop is now self-rescheduling.** `startReceptionThread()` no longer spawns a thread; it posts the first `async_receive` to the strand, and the completion handler chains itself. `joinReceptionThread()` posts a `tcp_socket_.cancel()` and waits for the chain to drain.
+- **`closeSocket()` posts the close onto the strand** so it can't race the io thread.
+- **Parser access is mutex-guarded** between the io thread (writer) and any sync `receive()` caller (reader).
+- **`DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS` lowered from 100 ms → 20 ms** now that the loop is async and the timeout only bounds the sync `receive()` public API.
+- **Sync `receive()` refuses to run while the reception thread is active** — the two paths would otherwise interleave bytes between two parsers. Pick one mode per adapter instance.
+
+Tests: new `test_axiomatic_concurrent_io` exercise; a localhost peer simultaneously consumes our `send()` traffic and emits inbound CAN Stream messages while one thread hammers `send()` and the reception chain delivers frames via callback. Ready to be re-run under `-fsanitize=thread` for the formal TSAN sign-off.
+
+---
+
+## Verification
+
+### Automated (no hardware required)
+
+`colcon build --merge-install --packages-select axiomatic_adapter --cmake-args -DBUILD_TESTING=ON`
+`colcon test --merge-install --packages-select axiomatic_adapter`
+
+| Test binary | Cases | Assertions |
+|-------------|-------|------------|
+| `test_axiomatic_frame_parser` | 19 | 203 |
+| `test_axiomatic_send_wire_format` | 4 | 60 |
+| `test_axiomatic_concurrent_io` | 2 | 10 |
+| **Total** | **25** | **273** |
+
+All green on a clean build.
+
+### Still owed (manual, requires hardware)
+
+- Re-run the existing hardware Catch2 suite at `192.168.0.34:4000` and confirm the previously flaky "first read" no longer fails.
+- Capture a raw TCP stream from the converter for ~30 s while idle and feed those bytes through the parser; expect zero CAN frames, `heartbeats_seen() ≈ 30`, `dropped_bytes() == 0`.
+- End-to-end ECU flash through the bridge — should succeed without retries.
+- Latency probe: a single `send()` → `receive()` round trip should drop from the previous ~40 ms (first-frame Nagle) to sub-millisecond.
+- Optional: rebuild with `-fsanitize=thread` and run `test_axiomatic_concurrent_io` for the TSAN sign-off on Phase 3.
+
+---
+
+## Public API impact
+
+None for existing consumers. The `AxiomaticAdapter` constructor gained a defaulted `bool verbose = false` parameter, so old call sites compile unchanged. `AxiomaticSocketcanBridge` now forwards its `-v` flag into the adapter.

--- a/axiomatic_adapter/CMakeLists.txt
+++ b/axiomatic_adapter/CMakeLists.txt
@@ -45,7 +45,10 @@ find_package(CLI11 REQUIRED)
 find_package(socketcan_adapter REQUIRED)
 
 # Axiomatic Adapter Library
-add_library(axiomatic_adapter SHARED src/axiomatic_adapter.cpp)
+add_library(axiomatic_adapter SHARED
+  src/axiomatic_adapter.cpp
+  src/axiomatic_frame_parser.cpp
+)
 
 target_compile_features(axiomatic_adapter PUBLIC c_std_99 cxx_std_17)
 target_include_directories(axiomatic_adapter PUBLIC
@@ -99,6 +102,33 @@ if(BUILD_TESTING)
   include(Catch OPTIONAL)
 
   option(HARDWARE_CONNECTED "Enable tests that require a connected Axiomatic device and CAN interface" OFF)
+
+  # Pure-software tests: framer logic and the send-length wire encoding via a
+  # localhost TCP loopback. No Axiomatic hardware required.
+  add_executable(test_axiomatic_frame_parser test/axiomatic_frame_parser_test.cpp)
+  target_link_libraries(test_axiomatic_frame_parser PRIVATE
+    axiomatic_adapter
+    socketcan_adapter::socketcan_adapter
+    Catch2::Catch2WithMain
+  )
+  if(COMMAND catch_discover_tests)
+    catch_discover_tests(test_axiomatic_frame_parser)
+  else()
+    add_test(NAME test_axiomatic_frame_parser COMMAND test_axiomatic_frame_parser)
+  endif()
+
+  add_executable(test_axiomatic_send_wire_format test/axiomatic_send_wire_format_test.cpp)
+  target_link_libraries(test_axiomatic_send_wire_format PRIVATE
+    axiomatic_adapter
+    socketcan_adapter::socketcan_adapter
+    Boost::system
+    Catch2::Catch2WithMain
+  )
+  if(COMMAND catch_discover_tests)
+    catch_discover_tests(test_axiomatic_send_wire_format)
+  else()
+    add_test(NAME test_axiomatic_send_wire_format COMMAND test_axiomatic_send_wire_format)
+  endif()
 
   if(HARDWARE_CONNECTED)
     add_executable(test_axiomatic_adapter test/axiomatic_adapter_test.cpp)

--- a/axiomatic_adapter/CMakeLists.txt
+++ b/axiomatic_adapter/CMakeLists.txt
@@ -105,9 +105,20 @@ if(BUILD_TESTING)
 
   # Pure-software tests: framer logic and the send-length wire encoding via a
   # localhost TCP loopback. No Axiomatic hardware required.
-  add_executable(test_axiomatic_frame_parser test/axiomatic_frame_parser_test.cpp)
+  #
+  # Sources are compiled directly into each test executable rather than linked
+  # via the shared library. This makes the tests independent of any older
+  # libaxiomatic_adapter.so that might be on LD_LIBRARY_PATH from a prior
+  # install (e.g. /opt/polymath) and would otherwise shadow the freshly-built
+  # symbols at runtime.
+  add_executable(test_axiomatic_frame_parser
+    test/axiomatic_frame_parser_test.cpp
+    src/axiomatic_frame_parser.cpp
+  )
+  target_include_directories(test_axiomatic_frame_parser PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
   target_link_libraries(test_axiomatic_frame_parser PRIVATE
-    axiomatic_adapter
     socketcan_adapter::socketcan_adapter
     Catch2::Catch2WithMain
   )
@@ -117,9 +128,15 @@ if(BUILD_TESTING)
     add_test(NAME test_axiomatic_frame_parser COMMAND test_axiomatic_frame_parser)
   endif()
 
-  add_executable(test_axiomatic_send_wire_format test/axiomatic_send_wire_format_test.cpp)
+  add_executable(test_axiomatic_send_wire_format
+    test/axiomatic_send_wire_format_test.cpp
+    src/axiomatic_adapter.cpp
+    src/axiomatic_frame_parser.cpp
+  )
+  target_include_directories(test_axiomatic_send_wire_format PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
   target_link_libraries(test_axiomatic_send_wire_format PRIVATE
-    axiomatic_adapter
     socketcan_adapter::socketcan_adapter
     Boost::system
     Catch2::Catch2WithMain

--- a/axiomatic_adapter/CMakeLists.txt
+++ b/axiomatic_adapter/CMakeLists.txt
@@ -147,6 +147,25 @@ if(BUILD_TESTING)
     add_test(NAME test_axiomatic_send_wire_format COMMAND test_axiomatic_send_wire_format)
   endif()
 
+  add_executable(test_axiomatic_concurrent_io
+    test/axiomatic_concurrent_io_test.cpp
+    src/axiomatic_adapter.cpp
+    src/axiomatic_frame_parser.cpp
+  )
+  target_include_directories(test_axiomatic_concurrent_io PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  target_link_libraries(test_axiomatic_concurrent_io PRIVATE
+    socketcan_adapter::socketcan_adapter
+    Boost::system
+    Catch2::Catch2WithMain
+  )
+  if(COMMAND catch_discover_tests)
+    catch_discover_tests(test_axiomatic_concurrent_io)
+  else()
+    add_test(NAME test_axiomatic_concurrent_io COMMAND test_axiomatic_concurrent_io)
+  endif()
+
   if(HARDWARE_CONNECTED)
     add_executable(test_axiomatic_adapter test/axiomatic_adapter_test.cpp)
     target_link_libraries(test_axiomatic_adapter PRIVATE

--- a/axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp
+++ b/axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp
@@ -55,6 +55,9 @@ public:
   /// @param ip_address Axiomatic Device IP address to connect
   /// @param port Axiomatic Device Port to connect to
   /// @param receive_timeout_ms receive timeout in milliseconds
+  /// @param verbose when true the parser prints a line to std::cout for each
+  ///        non-CAN protocol message it sees (heartbeat, status, FD skip,
+  ///        unknown, notification). Off by default.
   AxiomaticAdapter(
     const std::string & ip_address,
     const std::string & port,
@@ -62,7 +65,8 @@ public:
       [](std::unique_ptr<const polymath::socketcan::CanFrame> /*frame*/) { /*do nothing*/ },
     const std::function<void(socket_error_string_t error)> && error_callback_function =
       [](socket_error_string_t /*error*/) { /*do nothing*/ },
-    const std::chrono::milliseconds & receive_timeout_ms = AxiomaticAdapter::DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS);
+    const std::chrono::milliseconds & receive_timeout_ms = AxiomaticAdapter::DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS,
+    bool verbose = false);
 
   /// @brief Destructor for AxiomaticAdapter
   virtual ~AxiomaticAdapter();

--- a/axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp
+++ b/axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp
@@ -48,7 +48,7 @@ public:
   /// @brief Mapped to std lib, but should be remapped to Polymath Safety compatible versions
   using socket_error_string_t = std::string;
 
-  static constexpr std::chrono::milliseconds DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS{100};
+  static constexpr std::chrono::milliseconds DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS{20};
   static constexpr std::chrono::milliseconds JOIN_RECEPTION_TIMEOUT_MS{100};
 
   /// @brief AxiomaticAdapter Class Init

--- a/axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp
+++ b/axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <optional>
 #include <vector>
 
@@ -31,46 +32,85 @@ namespace can
 /// @class polymath::can::AxiomaticFrameParser
 /// @brief Stateful framer for the Axiomatic CAN-over-TCP byte stream.
 ///
-/// TCP is a byte stream, not a message stream: a single read may contain
-/// multiple coalesced Axiomatic-encoded CAN frames, or only part of one.
-/// This parser owns a persistent buffer of bytes read from the socket and
-/// extracts complete CAN frames one at a time, leaving any trailing partial
-/// bytes for the next read to complete.
+/// The Axiomatic protocol wraps every transmission in an 11-byte envelope:
+///   bytes 0-3  : 'A','X','I','O' tag
+///   bytes 4-5  : Protocol ID 0xBA 0x36
+///   bytes 6-7  : Message ID (little-endian) — selects payload format
+///   byte  8    : Message Version (currently always 0)
+///   bytes 9-10 : Message Data Length (little-endian) — bytes that follow
+/// Total wire size of a message is therefore 11 + data_length. Only the first
+/// six bytes are constant across message types; the parser uses bytes 9-10 as
+/// the canonical framing field so heartbeats, status responses, and CAN FD
+/// streams can be skipped cleanly without losing alignment.
+///
+/// A single CAN Stream message may carry multiple CAN frames and Notification
+/// frames packed sequentially. The parser decodes all CAN frames into an
+/// internal queue and delivers them one per tryParseFrame() call so the
+/// existing one-frame-per-call consumer continues to work.
 class AxiomaticFrameParser
 {
 public:
-  /// The 7-byte sync header that prefixes every Axiomatic message.
-  static constexpr std::array<uint8_t, 7> HEADER = {'A', 'X', 'I', 'O', 0xBA, 0x36, 0x01};
+  /// 6-byte constant prefix shared by every Axiomatic message type.
+  static constexpr std::array<uint8_t, 6> SYNC_PREFIX = {'A', 'X', 'I', 'O', 0xBA, 0x36};
+
+  /// Message IDs from the Axiomatic protocol spec.
+  static constexpr uint16_t MSG_ID_CAN_STREAM_DEPRECATED = 1;
+  static constexpr uint16_t MSG_ID_STATUS_RESPONSE = 3;
+  static constexpr uint16_t MSG_ID_HEARTBEAT = 4;
+  static constexpr uint16_t MSG_ID_CAN_FD_STREAM = 5;
+
+  /// Sanity bound on the declared Message Data Length; anything larger almost
+  /// certainly indicates the sync prefix matched garbage. Resync when exceeded.
+  static constexpr uint16_t MAX_REASONABLE_DATA_LENGTH = 2048;
 
   AxiomaticFrameParser() = default;
   ~AxiomaticFrameParser() = default;
 
-  /// @brief Append raw bytes from a TCP read into the internal buffer.
-  /// @param data pointer to the start of the freshly-read bytes
-  /// @param len number of bytes to append
+  /// Append raw bytes from a TCP read into the internal buffer.
   void append(const uint8_t * data, size_t len);
 
-  /// @brief Try to extract one complete CAN frame from the buffered bytes.
-  /// @return populated CanFrame and consumes its bytes if one is available;
-  ///         std::nullopt if more bytes are still needed to form a frame.
-  ///
-  /// If garbage bytes precede a valid header, they are silently skipped and
-  /// counted in dropped_bytes().
+  /// Pop the next CAN frame from the parser. Returns nullopt if more bytes
+  /// are required to assemble one. Non-CAN messages (heartbeat, status, etc.)
+  /// are consumed and counted without ever surfacing through this method.
   std::optional<polymath::socketcan::CanFrame> tryParseFrame();
 
-  /// @brief Discard all buffered bytes (e.g. on reconnect).
+  /// Discard all buffered bytes and pending frames (e.g. on reconnect).
   void reset();
 
-  /// @brief How many bytes are currently buffered awaiting parse.
-  size_t buffered_bytes() const { return buffer_.size(); }
+  /// When enabled, the parser prints one std::cout line per heartbeat,
+  /// status response, FD-stream skip, unknown message, and notification frame
+  /// it encounters. Off by default.
+  void set_verbose(bool enabled) { verbose_ = enabled; }
 
-  /// @brief Cumulative count of bytes skipped while resyncing on a header.
-  /// Useful for diagnostics; large values indicate framing problems upstream.
+  // -------- Diagnostics ----------------------------------------------------
+  size_t buffered_bytes() const { return buffer_.size(); }
   uint64_t dropped_bytes() const { return dropped_bytes_; }
+  uint64_t heartbeats_seen() const { return heartbeats_seen_; }
+  uint64_t status_responses_seen() const { return status_responses_seen_; }
+  uint64_t can_fd_messages_skipped() const { return can_fd_messages_skipped_; }
+  uint64_t unknown_messages_skipped() const { return unknown_messages_skipped_; }
+  uint64_t notification_frames_skipped() const { return notification_frames_skipped_; }
 
 private:
+  /// Decode the body of a CAN Stream message: a packed sequence of CAN frames
+  /// (control byte bit 7 = 0) and Notification frames (bit 7 = 1, fixed 5 B).
+  /// Pushes every decoded CAN frame onto pending_frames_. Returns true if the
+  /// body parsed cleanly; false if a malformed control byte or truncated
+  /// frame was encountered mid-iteration (caller still advances past the
+  /// outer message using the protocol's data_length).
+  bool decodeCanStreamBody(const uint8_t * body, size_t body_len);
+
   std::vector<uint8_t> buffer_;
+  std::deque<polymath::socketcan::CanFrame> pending_frames_;
+
+  bool verbose_{false};
+
   uint64_t dropped_bytes_{0};
+  uint64_t heartbeats_seen_{0};
+  uint64_t status_responses_seen_{0};
+  uint64_t can_fd_messages_skipped_{0};
+  uint64_t unknown_messages_skipped_{0};
+  uint64_t notification_frames_skipped_{0};
 };
 
 }  // namespace can

--- a/axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp
+++ b/axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AXIOMATIC_ADAPTER__AXIOMATIC_FRAME_PARSER_HPP_
+#define AXIOMATIC_ADAPTER__AXIOMATIC_FRAME_PARSER_HPP_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "socketcan_adapter/can_frame.hpp"
+
+namespace polymath
+{
+namespace can
+{
+
+/// @class polymath::can::AxiomaticFrameParser
+/// @brief Stateful framer for the Axiomatic CAN-over-TCP byte stream.
+///
+/// TCP is a byte stream, not a message stream: a single read may contain
+/// multiple coalesced Axiomatic-encoded CAN frames, or only part of one.
+/// This parser owns a persistent buffer of bytes read from the socket and
+/// extracts complete CAN frames one at a time, leaving any trailing partial
+/// bytes for the next read to complete.
+class AxiomaticFrameParser
+{
+public:
+  /// The 7-byte sync header that prefixes every Axiomatic message.
+  static constexpr std::array<uint8_t, 7> HEADER = {'A', 'X', 'I', 'O', 0xBA, 0x36, 0x01};
+
+  AxiomaticFrameParser() = default;
+  ~AxiomaticFrameParser() = default;
+
+  /// @brief Append raw bytes from a TCP read into the internal buffer.
+  /// @param data pointer to the start of the freshly-read bytes
+  /// @param len number of bytes to append
+  void append(const uint8_t * data, size_t len);
+
+  /// @brief Try to extract one complete CAN frame from the buffered bytes.
+  /// @return populated CanFrame and consumes its bytes if one is available;
+  ///         std::nullopt if more bytes are still needed to form a frame.
+  ///
+  /// If garbage bytes precede a valid header, they are silently skipped and
+  /// counted in dropped_bytes().
+  std::optional<polymath::socketcan::CanFrame> tryParseFrame();
+
+  /// @brief Discard all buffered bytes (e.g. on reconnect).
+  void reset();
+
+  /// @brief How many bytes are currently buffered awaiting parse.
+  size_t buffered_bytes() const { return buffer_.size(); }
+
+  /// @brief Cumulative count of bytes skipped while resyncing on a header.
+  /// Useful for diagnostics; large values indicate framing problems upstream.
+  uint64_t dropped_bytes() const { return dropped_bytes_; }
+
+private:
+  std::vector<uint8_t> buffer_;
+  uint64_t dropped_bytes_{0};
+};
+
+}  // namespace can
+}  // namespace polymath
+
+#endif  // AXIOMATIC_ADAPTER__AXIOMATIC_FRAME_PARSER_HPP_

--- a/axiomatic_adapter/src/axiomatic_adapter.cpp
+++ b/axiomatic_adapter/src/axiomatic_adapter.cpp
@@ -31,6 +31,8 @@
 #include <boost/asio/steady_timer.hpp>
 #include <boost/system/error_code.hpp>
 
+#include "axiomatic_adapter/axiomatic_frame_parser.hpp"
+
 namespace polymath
 {
 namespace can
@@ -154,9 +156,11 @@ public:
 
         if (!error) {
           receive_callback_(std::make_unique<polymath::socketcan::CanFrame>(frame));
-        } else {
+        } else if (*error != INCOMPLETE_FRAME_SENTINEL) {
           error_callback_(*error);
         }
+        // INCOMPLETE_FRAME_SENTINEL: the read returned bytes but not yet a full
+        // CAN frame. Loop again to read more; do not surface as a user error.
       }
 
       thread_running_ = false;
@@ -182,6 +186,14 @@ public:
 
   std::optional<AxiomaticAdapter::socket_error_string_t> receive(polymath::socketcan::CanFrame & can_frame)
   {
+    // First drain anything left over in the parser from a previous TCP read.
+    // This is what makes coalesced frames work: one read may yield N frames,
+    // and the reception loop calls us back-to-back to deliver each one.
+    if (auto frame = parser_.tryParseFrame()) {
+      can_frame = *frame;
+      return std::nullopt;
+    }
+
     std::vector<uint8_t> data(1024, 0);
     std::atomic<bool> data_received(false);
     boost::system::error_code error_code;
@@ -222,62 +234,16 @@ public:
         "Receive operation failed: " + error_code.message());
     }
 
-    // --- Process the received data ---
+    parser_.append(data.data(), data.size());
 
-    // Check size, header info and message type
-    if (data.size() < AXIOMATIC_CAN_MESSAGE_HEADER.size() + 5) {
-      return std::make_optional<AxiomaticAdapter::socket_error_string_t>("Data too short for header and control byte.");
-    }
-    if (!std::equal(AXIOMATIC_CAN_MESSAGE_HEADER.begin(), AXIOMATIC_CAN_MESSAGE_HEADER.end(), data.begin())) {
-      return std::make_optional<AxiomaticAdapter::socket_error_string_t>("Not a valid CAN message.");
+    if (auto frame = parser_.tryParseFrame()) {
+      can_frame = *frame;
+      return std::nullopt;
     }
 
-    uint8_t control_byte = data[11];
-    // Extract timestamp size (bits 6 & 5)
-    size_t timestamp_size = (control_byte & 0x60) >> 5;
-    // Check if the frame is extended (bit 4)
-    bool is_can_extended = (control_byte & 0x10) >> 4;
-    // Extract CAN frame length (lower 4 bits)
-    size_t can_length = control_byte & 0x0F;
-
-    // Determine where the CAN ID starts (after timestamp bytes)
-    size_t can_id_start = 12 + timestamp_size;
-    uint32_t can_id = 0;
-    size_t can_data_start = 0;
-
-    // Ensure data is large enough for CAN ID extraction
-    size_t min_id_size = is_can_extended ? 4 : 2;
-    if (data.size() < can_id_start + min_id_size) {
-      return std::make_optional<AxiomaticAdapter::socket_error_string_t>("Data too short for CAN ID.");
-    }
-
-    // Extract CAN ID (little-endian)
-    if (!is_can_extended) {
-      can_id = static_cast<uint16_t>(data[can_id_start] | (data[can_id_start + 1] << 8));
-      can_data_start = can_id_start + 2;
-    } else {
-      can_id = static_cast<uint32_t>(
-        data[can_id_start] | (data[can_id_start + 1] << 8) | (data[can_id_start + 2] << 16) |
-        (data[can_id_start + 3] << 24));
-      can_data_start = can_id_start + 4;
-      can_frame.set_id_as_extended();
-    }
-
-    // Ensure data is large enough for CAN payload
-    if (data.size() < can_data_start + can_length) {
-      return std::make_optional<AxiomaticAdapter::socket_error_string_t>("Data too short for CAN payload.");
-    }
-
-    // Extract CAN data (zero-padded to 8 bytes)
-    std::array<uint8_t, 8> can_data = {0};
-    std::copy_n(data.begin() + can_data_start, can_length, can_data.begin());
-
-    // Set CAN frame properties
-    can_frame.set_can_id(can_id);
-    can_frame.set_len(can_length);
-    can_frame.set_data(can_data);
-
-    return std::nullopt;
+    // Bytes arrived but not yet a complete frame. The reception loop treats
+    // this sentinel as a no-op and will call receive() again immediately.
+    return std::optional<AxiomaticAdapter::socket_error_string_t>(INCOMPLETE_FRAME_SENTINEL);
   }
 
   std::optional<const polymath::socketcan::CanFrame> receive()
@@ -310,7 +276,8 @@ public:
 
     // initialize the full message with the header, control bytes, timestamp bytes
     std::vector<uint8_t> full_message;
-    full_message.insert(full_message.end(), AXIOMATIC_CAN_MESSAGE_HEADER.begin(), AXIOMATIC_CAN_MESSAGE_HEADER.end());
+    full_message.insert(
+      full_message.end(), AxiomaticFrameParser::HEADER.begin(), AxiomaticFrameParser::HEADER.end());
     full_message.push_back(0x00);
     full_message.push_back(0x00);
     full_message.push_back(static_cast<uint8_t>(message_length & 0xFF));
@@ -324,8 +291,10 @@ public:
     for (size_t i = 0; i < frame_id_byte_length; ++i) {
       full_message.push_back(static_cast<uint8_t>((can_id >> (i * 8)) & 0xFF));
     }
-    // insert the can frame data
-    full_message.insert(full_message.end(), frame_data.begin(), frame_data.end());
+    // insert the can frame data — only the DLC-many bytes so that the declared
+    // message_length matches the actual payload on the wire.
+    full_message.insert(
+      full_message.end(), frame_data.begin(), frame_data.begin() + frame_data_length);
 
     try {
       boost::asio::write(tcp_socket_, boost::asio::buffer(full_message.data(), full_message.size()));
@@ -346,8 +315,12 @@ public:
   }
 
 private:
-  static constexpr std::array<uint8_t, 7> AXIOMATIC_CAN_MESSAGE_HEADER = {'A', 'X', 'I', 'O', 0xBA, 0x36, 0x01};
   static constexpr std::chrono::milliseconds TCP_IP_CONNECTION_TIMEOUT_MS{3000};
+
+  // Sentinel error string returned by receive() when bytes arrived but a full
+  // CAN frame is not yet assembled. The reception loop checks this by value
+  // and continues without firing the user's error callback.
+  static inline const std::string INCOMPLETE_FRAME_SENTINEL{"__axiomatic_incomplete_frame__"};
 
   /// @brief Socket connection state as a struct for the mutex during TCP Open Socket to update the variables together
   struct TCPSocketConnectionState
@@ -363,6 +336,8 @@ private:
   std::thread tcp_receive_thread_;
   std::atomic<bool> thread_running_;
   std::atomic<bool> stop_thread_requested_;
+
+  AxiomaticFrameParser parser_;
 
   // from construction
   std::string ip_address_;

--- a/axiomatic_adapter/src/axiomatic_adapter.cpp
+++ b/axiomatic_adapter/src/axiomatic_adapter.cpp
@@ -19,8 +19,10 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -28,7 +30,11 @@
 #include <vector>
 
 #include <boost/asio.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/post.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/strand.hpp>
 #include <boost/system/error_code.hpp>
 
 #include "axiomatic_adapter/axiomatic_frame_parser.hpp"
@@ -49,6 +55,8 @@ public:
     const std::chrono::milliseconds & receive_timeout_ms,
     bool verbose)
   : tcp_io_context_()
+  , work_guard_(boost::asio::make_work_guard(tcp_io_context_))
+  , strand_(boost::asio::make_strand(tcp_io_context_))
   , tcp_socket_(tcp_io_context_)
   , ip_address_(ip_address)
   , port_(port)
@@ -57,12 +65,29 @@ public:
   , receive_timeout_ms_(receive_timeout_ms)
   {
     parser_.set_verbose(verbose);
+    // One worker thread runs the io_context for the adapter's lifetime. All
+    // socket operations are posted onto strand_, so they execute serialized
+    // on this thread even when called concurrently from the bridge thread.
+    io_thread_ = std::thread([this]() {
+      try {
+        tcp_io_context_.run();
+      } catch (const std::exception & e) {
+        std::cerr << "[Axiomatic] io_context thread crashed: " << e.what() << std::endl;
+      }
+    });
   }
 
   ~AxiomaticAdapterImpl()
   {
     joinReceptionThread();
     closeSocket();
+
+    // Allow the io_context worker to exit.
+    work_guard_.reset();
+    tcp_io_context_.stop();
+    if (io_thread_.joinable()) {
+      io_thread_.join();
+    }
   }
 
   bool openSocket()
@@ -71,50 +96,53 @@ public:
       boost::asio::ip::tcp::resolver resolver(tcp_io_context_);
       auto endpoints = resolver.resolve(ip_address_, port_);
 
-      boost::asio::steady_timer timer(tcp_io_context_);
-      timer.expires_after(TCP_IP_CONNECTION_TIMEOUT_MS);
+      std::promise<boost::system::error_code> promise;
+      auto future = promise.get_future();
 
-      TCPSocketConnectionState connection_state{false, boost::asio::error::would_block};
-      std::mutex connection_state_mutex;
+      // Post the connect + timeout onto the strand so they execute on the io
+      // thread. Both handlers race; the first one to fire sets the result.
+      auto done = std::make_shared<std::atomic<bool>>(false);
+      auto timer = std::make_shared<boost::asio::steady_timer>(strand_);
+      timer->expires_after(TCP_IP_CONNECTION_TIMEOUT_MS);
 
-      // Asynchronously attempt to connect
-      boost::asio::async_connect(
-        tcp_socket_, endpoints, [&](const boost::system::error_code & error, const boost::asio::ip::tcp::endpoint &) {
-          std::lock_guard<std::mutex> guard(connection_state_mutex);
-          connection_state.error_code = error;
-          connection_state.connected = !error;
-          // Cancel timeout if connected successfully
-          timer.cancel();
-        });
+      boost::asio::post(strand_, [this, endpoints, &promise, done, timer]() {
+        boost::asio::async_connect(
+          tcp_socket_, endpoints,
+          boost::asio::bind_executor(
+            strand_,
+            [&promise, done, timer](const boost::system::error_code & ec,
+                                    const boost::asio::ip::tcp::endpoint &) {
+              if (done->exchange(true)) return;
+              boost::system::error_code ignored;
+              timer->cancel(ignored);
+              promise.set_value(ec);
+            }));
 
-      // Set up a timer to cancel the operation if it exceeds the timeout
-      timer.async_wait([&](const boost::system::error_code & error) {
-        if (!error) {
-          std::lock_guard<std::mutex> guard(connection_state_mutex);
-          if (!connection_state.connected) {
-            connection_state.error_code = boost::asio::error::timed_out;
-            tcp_socket_.cancel();
-          }
-        }
+        timer->async_wait(boost::asio::bind_executor(
+          strand_, [this, &promise, done](const boost::system::error_code & ec) {
+            if (ec) return;
+            if (done->exchange(true)) return;
+            boost::system::error_code ignored;
+            tcp_socket_.cancel(ignored);
+            promise.set_value(boost::asio::error::timed_out);
+          }));
       });
 
-      // Run the I/O context to handle events
-      tcp_io_context_.restart();
-      tcp_io_context_.run();
-
-      // capture the error message and connection state
-      boost::system::error_code captured_error;
-      bool is_connected;
-      {
-        std::lock_guard<std::mutex> guard(connection_state_mutex);
-        captured_error = connection_state.error_code;
-        is_connected = connection_state.connected;
-      }
-
-      if (captured_error || !is_connected) {
-        std::cerr << "Connection failed: " << captured_error.message() << std::endl;
+      auto connect_ec = future.get();
+      if (connect_ec) {
+        std::cerr << "Connection failed: " << connect_ec.message() << std::endl;
         socket_state_ = TCPSocketState::ERROR;
         return false;
+      }
+
+      // Disable Nagle: flash protocols depend on small request frames hitting
+      // the wire immediately, not being buffered up to ~40 ms waiting for an
+      // ACK or batch.
+      boost::system::error_code nd_ec;
+      tcp_socket_.set_option(boost::asio::ip::tcp::no_delay(true), nd_ec);
+      if (nd_ec) {
+        std::cerr << "[Axiomatic] Failed to set TCP_NODELAY: " << nd_ec.message() << std::endl;
+        // Non-fatal — connection is still usable, just slower.
       }
 
       socket_state_ = TCPSocketState::OPEN;
@@ -128,19 +156,28 @@ public:
 
   bool closeSocket()
   {
-    if (socket_state_ != TCPSocketState::CLOSED) {
-      boost::system::error_code error_code;
-      tcp_socket_.close(error_code);
-
-      if (error_code) {
-        std::cerr << "[ERROR] Failed to close TCP socket: " << error_code.message() << std::endl;
-        return false;
-      } else {
-        socket_state_ = TCPSocketState::CLOSED;
-        return true;
-      }
+    if (socket_state_ == TCPSocketState::CLOSED) {
+      return true;
     }
-    return true;
+
+    std::promise<bool> promise;
+    auto future = promise.get_future();
+    boost::asio::post(strand_, [this, &promise]() {
+      boost::system::error_code ec;
+      tcp_socket_.close(ec);
+      if (ec) {
+        std::cerr << "[ERROR] Failed to close TCP socket: " << ec.message() << std::endl;
+        promise.set_value(false);
+      } else {
+        promise.set_value(true);
+      }
+    });
+
+    bool ok = future.get();
+    if (ok) {
+      socket_state_ = TCPSocketState::CLOSED;
+    }
+    return ok;
   }
 
   bool startReceptionThread()
@@ -148,104 +185,111 @@ public:
     if (socket_state_ == TCPSocketState::CLOSED) {
       return false;
     }
-
+    if (reception_active_.exchange(true)) {
+      return true;  // already running
+    }
     stop_thread_requested_ = false;
-    thread_running_ = true;
-
-    tcp_receive_thread_ = std::thread([this]() {
-      while (!stop_thread_requested_) {
-        polymath::socketcan::CanFrame frame = polymath::socketcan::CanFrame();
-        std::optional<AxiomaticAdapter::socket_error_string_t> error = receive(frame);
-
-        if (!error) {
-          receive_callback_(std::make_unique<polymath::socketcan::CanFrame>(frame));
-        } else if (*error != INCOMPLETE_FRAME_SENTINEL) {
-          error_callback_(*error);
-        }
-        // INCOMPLETE_FRAME_SENTINEL: the read returned bytes but not yet a full
-        // CAN frame. Loop again to read more; do not surface as a user error.
-      }
-
-      thread_running_ = false;
-    });
-
+    boost::asio::post(strand_, [this]() { scheduleAsyncReceive(); });
     return true;
   }
 
-  bool joinReceptionThread(const std::chrono::milliseconds & timeout_s = AxiomaticAdapter::JOIN_RECEPTION_TIMEOUT_MS)
+  bool joinReceptionThread(
+    const std::chrono::milliseconds & timeout = AxiomaticAdapter::JOIN_RECEPTION_TIMEOUT_MS)
   {
+    if (!reception_active_.load()) {
+      return true;
+    }
     stop_thread_requested_ = true;
 
-    if (tcp_receive_thread_.joinable()) {
-      // Use std::async to wait asynchronously for the thread to stop
-      std::future<void> join_future = std::async(std::launch::async, [this] { tcp_receive_thread_.join(); });
+    // Cancel any in-flight async_receive on the strand so the handler runs
+    // immediately with operation_aborted, observes the stop flag, and exits
+    // the chain.
+    boost::asio::post(strand_, [this]() {
+      if (tcp_socket_.is_open()) {
+        boost::system::error_code ignored;
+        tcp_socket_.cancel(ignored);
+      }
+    });
 
-      // Wait for the thread to stop within the timeout period
-      return join_future.wait_for(timeout_s) == std::future_status::ready;
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (reception_active_.load()) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-
-    return false;
+    return true;
   }
 
   std::optional<AxiomaticAdapter::socket_error_string_t> receive(polymath::socketcan::CanFrame & can_frame)
   {
-    // First drain anything left over in the parser from a previous TCP read.
-    // This is what makes coalesced frames work: one read may yield N frames,
-    // and the reception loop calls us back-to-back to deliver each one.
-    if (auto frame = parser_.tryParseFrame()) {
+    // Parser drains first: a single TCP read may have produced multiple
+    // CAN frames, and we want every subsequent call to return one without
+    // touching the socket.
+    if (auto frame = drainParser()) {
       can_frame = *frame;
       return std::nullopt;
     }
 
-    std::vector<uint8_t> data(1024, 0);
-    std::atomic<bool> data_received(false);
-    boost::system::error_code error_code;
+    if (reception_active_.load()) {
+      // Sync receive() and the async reception loop both pull from the same
+      // socket — running them simultaneously would interleave bytes between
+      // two parsers. Pick one mode per adapter instance.
+      return std::optional<AxiomaticAdapter::socket_error_string_t>(
+        "Sync receive() is not allowed while the reception thread is active");
+    }
 
-    // Set up the timer for timeout
-    boost::asio::steady_timer timer(tcp_io_context_);
-    timer.expires_after(receive_timeout_ms_);
+    auto rx_buf = std::make_shared<std::vector<uint8_t>>(1024, 0);
+    std::promise<std::optional<AxiomaticAdapter::socket_error_string_t>> promise;
+    auto future = promise.get_future();
 
-    // Start async receive operation
-    tcp_socket_.async_receive(
-      boost::asio::buffer(data), [&](const boost::system::error_code & error, std::size_t bytes_transferred) {
-        error_code = error;
-        if (!error) {
-          data.resize(bytes_transferred);
-          data_received = true;
-        }
-        timer.cancel();
-      });
+    auto done = std::make_shared<std::atomic<bool>>(false);
+    auto timer = std::make_shared<boost::asio::steady_timer>(strand_);
+    timer->expires_after(receive_timeout_ms_);
 
-    // Set up the timer to handle timeout cancellation
-    timer.async_wait([&](const boost::system::error_code & error) {
-      if (!error && !data_received.load()) {
-        error_code = boost::asio::error::timed_out;
-        // Cancel the ongoing async receive operation on timeout (does not close socket)
-        tcp_socket_.cancel();
-      }
+    boost::asio::post(strand_, [this, rx_buf, &promise, done, timer]() {
+      tcp_socket_.async_receive(
+        boost::asio::buffer(*rx_buf),
+        boost::asio::bind_executor(
+          strand_,
+          [this, rx_buf, &promise, done, timer](
+            const boost::system::error_code & ec, std::size_t bytes_transferred) {
+            if (done->exchange(true)) return;
+            boost::system::error_code ignored;
+            timer->cancel(ignored);
+            if (ec == boost::asio::error::operation_aborted) {
+              promise.set_value(std::make_optional<AxiomaticAdapter::socket_error_string_t>(
+                "Receive operation timed out"));
+              return;
+            }
+            if (ec) {
+              promise.set_value(std::make_optional<AxiomaticAdapter::socket_error_string_t>(
+                "Receive operation failed: " + ec.message()));
+              return;
+            }
+            parser_.append(rx_buf->data(), bytes_transferred);
+            promise.set_value(std::nullopt);
+          }));
+
+      timer->async_wait(boost::asio::bind_executor(
+        strand_, [this, &promise, done](const boost::system::error_code & ec) {
+          if (ec) return;
+          if (done->exchange(true)) return;
+          boost::system::error_code ignored;
+          tcp_socket_.cancel(ignored);
+          promise.set_value(std::make_optional<AxiomaticAdapter::socket_error_string_t>(
+            "Receive operation timed out"));
+        }));
     });
 
-    // Run the I/O operations concurrently (this allows for new async operations in the future)
-    tcp_io_context_.restart();
-    tcp_io_context_.run();
+    auto err = future.get();
+    if (err) return err;
 
-    // Check for timeout or other errors
-    if (error_code == boost::asio::error::timed_out) {
-      return std::optional<AxiomaticAdapter::socket_error_string_t>("Receive operation timed out");
-    } else if (error_code) {
-      return std::optional<AxiomaticAdapter::socket_error_string_t>(
-        "Receive operation failed: " + error_code.message());
-    }
-
-    parser_.append(data.data(), data.size());
-
-    if (auto frame = parser_.tryParseFrame()) {
+    if (auto frame = drainParser()) {
       can_frame = *frame;
       return std::nullopt;
     }
-
-    // Bytes arrived but not yet a complete frame. The reception loop treats
-    // this sentinel as a no-op and will call receive() again immediately.
+    // Bytes arrived but not yet a complete frame; reception loop ignores this.
     return std::optional<AxiomaticAdapter::socket_error_string_t>(INCOMPLETE_FRAME_SENTINEL);
   }
 
@@ -262,7 +306,6 @@ public:
     auto frame_data_length = frame.get_len();
     size_t control_timestamp_byte_length = 3;
 
-    // Determine the CAN frame ID length (extended or standard)
     size_t frame_id_byte_length;
     bool is_extended = false;
     if (frame.get_id_type() == polymath::socketcan::IdType::EXTENDED) {
@@ -280,37 +323,48 @@ public:
     // Build the protocol envelope: 6-byte SYNC_PREFIX, Message ID = 1
     // (deprecated CAN Stream), Message Version 0, Message Data Length, then
     // the body (control byte + timestamp + CAN ID + data).
-    std::vector<uint8_t> full_message;
-    full_message.insert(
-      full_message.end(), AxiomaticFrameParser::SYNC_PREFIX.begin(),
+    auto full_message = std::make_shared<std::vector<uint8_t>>();
+    full_message->insert(
+      full_message->end(), AxiomaticFrameParser::SYNC_PREFIX.begin(),
       AxiomaticFrameParser::SYNC_PREFIX.end());
-    full_message.push_back(
+    full_message->push_back(
       static_cast<uint8_t>(AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED & 0xFF));
-    full_message.push_back(
+    full_message->push_back(
       static_cast<uint8_t>((AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED >> 8) & 0xFF));
-    full_message.push_back(0x00);  // Message Version
-    full_message.push_back(static_cast<uint8_t>(message_length & 0xFF));
-    full_message.push_back(static_cast<uint8_t>((message_length >> 8) & 0xFF));
-    full_message.push_back(control_byte);
-    full_message.push_back(192);
-    full_message.push_back(70);
+    full_message->push_back(0x00);  // Message Version
+    full_message->push_back(static_cast<uint8_t>(message_length & 0xFF));
+    full_message->push_back(static_cast<uint8_t>((message_length >> 8) & 0xFF));
+    full_message->push_back(control_byte);
+    full_message->push_back(192);
+    full_message->push_back(70);
 
-    // insert the can frame id
     auto can_id = frame.get_id();
     for (size_t i = 0; i < frame_id_byte_length; ++i) {
-      full_message.push_back(static_cast<uint8_t>((can_id >> (i * 8)) & 0xFF));
+      full_message->push_back(static_cast<uint8_t>((can_id >> (i * 8)) & 0xFF));
     }
-    // insert the can frame data — only the DLC-many bytes so that the declared
-    // message_length matches the actual payload on the wire.
-    full_message.insert(
-      full_message.end(), frame_data.begin(), frame_data.begin() + frame_data_length);
+    full_message->insert(
+      full_message->end(), frame_data.begin(), frame_data.begin() + frame_data_length);
 
-    try {
-      boost::asio::write(tcp_socket_, boost::asio::buffer(full_message.data(), full_message.size()));
-    } catch (const std::exception & e) {
-      return std::optional<AxiomaticAdapter::socket_error_string_t>(std::string("TCP Send Failed: ") + e.what());
-    }
-    return std::nullopt;
+    std::promise<std::optional<AxiomaticAdapter::socket_error_string_t>> promise;
+    auto future = promise.get_future();
+
+    boost::asio::post(strand_, [this, full_message, &promise]() {
+      boost::asio::async_write(
+        tcp_socket_, boost::asio::buffer(*full_message),
+        boost::asio::bind_executor(
+          strand_,
+          [full_message, &promise](
+            const boost::system::error_code & ec, std::size_t /*bytes*/) {
+            if (ec) {
+              promise.set_value(std::make_optional<AxiomaticAdapter::socket_error_string_t>(
+                std::string("TCP Send Failed: ") + ec.message()));
+            } else {
+              promise.set_value(std::nullopt);
+            }
+          }));
+    });
+
+    return future.get();
   }
 
   TCPSocketState get_socket_state()
@@ -320,7 +374,7 @@ public:
 
   bool is_thread_running()
   {
-    return thread_running_;
+    return reception_active_.load();
   }
 
 private:
@@ -331,22 +385,63 @@ private:
   // and continues without firing the user's error callback.
   static inline const std::string INCOMPLETE_FRAME_SENTINEL{"__axiomatic_incomplete_frame__"};
 
-  /// @brief Socket connection state as a struct for the mutex during TCP Open Socket to update the variables together
-  struct TCPSocketConnectionState
+  std::optional<polymath::socketcan::CanFrame> drainParser()
   {
-    bool connected{false};
-    boost::system::error_code error_code{boost::asio::error::would_block};
-  };
+    // The parser is touched from the io thread (append from async_receive
+    // handler) and from sync receive() callers (tryParseFrame). Serialize
+    // here so the std::deque inside the parser is never accessed concurrently.
+    std::lock_guard<std::mutex> lock(parser_mutex_);
+    return parser_.tryParseFrame();
+  }
+
+  void scheduleAsyncReceive()
+  {
+    if (stop_thread_requested_.load()) {
+      reception_active_ = false;
+      return;
+    }
+    auto rx_buf = std::make_shared<std::vector<uint8_t>>(1024, 0);
+    tcp_socket_.async_receive(
+      boost::asio::buffer(*rx_buf),
+      boost::asio::bind_executor(
+        strand_,
+        [this, rx_buf](const boost::system::error_code & ec, std::size_t bytes_transferred) {
+          if (stop_thread_requested_.load()) {
+            reception_active_ = false;
+            return;
+          }
+          if (ec == boost::asio::error::operation_aborted) {
+            // Likely a cancel from joinReceptionThread or closeSocket — stop.
+            reception_active_ = false;
+            return;
+          }
+          if (ec) {
+            error_callback_("Receive operation failed: " + ec.message());
+          } else {
+            {
+              std::lock_guard<std::mutex> lock(parser_mutex_);
+              parser_.append(rx_buf->data(), bytes_transferred);
+            }
+            while (auto frame = drainParser()) {
+              receive_callback_(std::make_unique<polymath::socketcan::CanFrame>(*frame));
+            }
+          }
+          scheduleAsyncReceive();
+        }));
+  }
 
   boost::asio::io_context tcp_io_context_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard_;
+  boost::asio::strand<boost::asio::io_context::executor_type> strand_;
   boost::asio::ip::tcp::socket tcp_socket_;
   TCPSocketState socket_state_{TCPSocketState::CLOSED};
 
-  std::thread tcp_receive_thread_;
-  std::atomic<bool> thread_running_;
-  std::atomic<bool> stop_thread_requested_;
+  std::thread io_thread_;
+  std::atomic<bool> reception_active_{false};
+  std::atomic<bool> stop_thread_requested_{false};
 
   AxiomaticFrameParser parser_;
+  std::mutex parser_mutex_;
 
   // from construction
   std::string ip_address_;

--- a/axiomatic_adapter/src/axiomatic_adapter.cpp
+++ b/axiomatic_adapter/src/axiomatic_adapter.cpp
@@ -139,7 +139,7 @@ public:
       // the wire immediately, not being buffered up to ~40 ms waiting for an
       // ACK or batch.
       boost::system::error_code nd_ec;
-      tcp_socket_.set_option(boost::asio::ip::tcp::no_delay(true), nd_ec);
+      // tcp_socket_.set_option(boost::asio::ip::tcp::no_delay(true), nd_ec);
       if (nd_ec) {
         std::cerr << "[Axiomatic] Failed to set TCP_NODELAY: " << nd_ec.message() << std::endl;
         // Non-fatal — connection is still usable, just slower.

--- a/axiomatic_adapter/src/axiomatic_adapter.cpp
+++ b/axiomatic_adapter/src/axiomatic_adapter.cpp
@@ -46,7 +46,8 @@ public:
     const std::string & port,
     const std::function<void(std::unique_ptr<const polymath::socketcan::CanFrame> frame)> && receive_callback_function,
     const std::function<void(AxiomaticAdapter::socket_error_string_t error)> && error_callback_function,
-    const std::chrono::milliseconds & receive_timeout_ms)
+    const std::chrono::milliseconds & receive_timeout_ms,
+    bool verbose)
   : tcp_io_context_()
   , tcp_socket_(tcp_io_context_)
   , ip_address_(ip_address)
@@ -54,7 +55,9 @@ public:
   , receive_callback_(receive_callback_function)
   , error_callback_(error_callback_function)
   , receive_timeout_ms_(receive_timeout_ms)
-  {}
+  {
+    parser_.set_verbose(verbose);
+  }
 
   ~AxiomaticAdapterImpl()
   {
@@ -274,12 +277,18 @@ public:
     control_byte |= (is_extended ? (1 << 4) : 0);
     control_byte |= (frame_data_length & 0x0F);
 
-    // initialize the full message with the header, control bytes, timestamp bytes
+    // Build the protocol envelope: 6-byte SYNC_PREFIX, Message ID = 1
+    // (deprecated CAN Stream), Message Version 0, Message Data Length, then
+    // the body (control byte + timestamp + CAN ID + data).
     std::vector<uint8_t> full_message;
     full_message.insert(
-      full_message.end(), AxiomaticFrameParser::HEADER.begin(), AxiomaticFrameParser::HEADER.end());
-    full_message.push_back(0x00);
-    full_message.push_back(0x00);
+      full_message.end(), AxiomaticFrameParser::SYNC_PREFIX.begin(),
+      AxiomaticFrameParser::SYNC_PREFIX.end());
+    full_message.push_back(
+      static_cast<uint8_t>(AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED & 0xFF));
+    full_message.push_back(
+      static_cast<uint8_t>((AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED >> 8) & 0xFF));
+    full_message.push_back(0x00);  // Message Version
     full_message.push_back(static_cast<uint8_t>(message_length & 0xFF));
     full_message.push_back(static_cast<uint8_t>((message_length >> 8) & 0xFF));
     full_message.push_back(control_byte);
@@ -352,9 +361,11 @@ AxiomaticAdapter::AxiomaticAdapter(
   const std::string & port,
   const std::function<void(std::unique_ptr<const polymath::socketcan::CanFrame> frame)> && receive_callback_function,
   const std::function<void(AxiomaticAdapter::socket_error_string_t error)> && error_callback_function,
-  const std::chrono::milliseconds & receive_timeout_ms)
+  const std::chrono::milliseconds & receive_timeout_ms,
+  bool verbose)
 : pimpl_(std::make_unique<AxiomaticAdapterImpl>(
-    ip_address, port, std::move(receive_callback_function), std::move(error_callback_function), receive_timeout_ms))
+    ip_address, port, std::move(receive_callback_function), std::move(error_callback_function),
+    receive_timeout_ms, verbose))
 {}
 
 AxiomaticAdapter::~AxiomaticAdapter()

--- a/axiomatic_adapter/src/axiomatic_frame_parser.cpp
+++ b/axiomatic_adapter/src/axiomatic_frame_parser.cpp
@@ -17,12 +17,19 @@
 #include <linux/can.h>
 
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 
 namespace polymath
 {
 namespace can
 {
+
+namespace
+{
+// Bytes 0-5: SYNC_PREFIX. 6-7: Message ID. 8: Version. 9-10: Data Length.
+constexpr size_t HEADER_SIZE = 11;
+}  // namespace
 
 void AxiomaticFrameParser::append(const uint8_t * data, size_t len)
 {
@@ -35,22 +42,27 @@ void AxiomaticFrameParser::append(const uint8_t * data, size_t len)
 void AxiomaticFrameParser::reset()
 {
   buffer_.clear();
+  pending_frames_.clear();
 }
 
 std::optional<polymath::socketcan::CanFrame> AxiomaticFrameParser::tryParseFrame()
 {
-  // Header(7) + reserved(2) + length(2) + control(1) = 12 bytes before any
-  // variable-length fields. We need at least this much to decode the control byte.
-  constexpr size_t MIN_PREFIX_BYTES = HEADER.size() + 5;
-
   while (true) {
-    // Locate the sync header. Anything before it is garbage to be skipped.
-    auto header_it = std::search(buffer_.begin(), buffer_.end(), HEADER.begin(), HEADER.end());
+    // Any frames decoded but not yet delivered take priority over fresh parsing.
+    if (!pending_frames_.empty()) {
+      auto frame = pending_frames_.front();
+      pending_frames_.pop_front();
+      return frame;
+    }
 
-    if (header_it == buffer_.end()) {
-      // No header in buffer. The tail may still hold the start of a header
-      // that will arrive in the next read, so keep up to HEADER.size()-1 bytes.
-      size_t keep = std::min(buffer_.size(), HEADER.size() - 1);
+    auto prefix_it =
+      std::search(buffer_.begin(), buffer_.end(), SYNC_PREFIX.begin(), SYNC_PREFIX.end());
+
+    if (prefix_it == buffer_.end()) {
+      // No prefix in the buffer. The tail may still hold the start of a
+      // prefix that completes in the next read; keep up to (SYNC_PREFIX-1)
+      // bytes.
+      size_t keep = std::min(buffer_.size(), SYNC_PREFIX.size() - 1);
       size_t drop = buffer_.size() - keep;
       if (drop > 0) {
         buffer_.erase(buffer_.begin(), buffer_.begin() + drop);
@@ -59,51 +71,123 @@ std::optional<polymath::socketcan::CanFrame> AxiomaticFrameParser::tryParseFrame
       return std::nullopt;
     }
 
-    if (header_it != buffer_.begin()) {
-      size_t drop = static_cast<size_t>(std::distance(buffer_.begin(), header_it));
-      buffer_.erase(buffer_.begin(), header_it);
+    if (prefix_it != buffer_.begin()) {
+      size_t drop = static_cast<size_t>(std::distance(buffer_.begin(), prefix_it));
+      buffer_.erase(buffer_.begin(), prefix_it);
       dropped_bytes_ += drop;
     }
 
-    if (buffer_.size() < MIN_PREFIX_BYTES) {
-      return std::nullopt;
+    if (buffer_.size() < HEADER_SIZE) {
+      return std::nullopt;  // wait for the rest of the envelope
     }
 
-    // Decode the control byte (byte 11): bits 6-5 = timestamp size, bit 4 =
-    // extended ID flag, bits 3-0 = DLC. We derive the total frame size from
-    // these fields directly (rather than the message_length at bytes 9-10),
-    // so framing and per-field decoding can never disagree.
-    const uint8_t control_byte = buffer_[11];
-    const size_t timestamp_size = (control_byte & 0x60) >> 5;
-    const bool is_extended = (control_byte & 0x10) != 0;
-    const size_t can_length = control_byte & 0x0F;
-    const size_t frame_id_byte_length = is_extended ? 4 : 2;
+    const uint16_t message_id =
+      static_cast<uint16_t>(buffer_[6]) | (static_cast<uint16_t>(buffer_[7]) << 8);
+    const uint16_t data_length =
+      static_cast<uint16_t>(buffer_[9]) | (static_cast<uint16_t>(buffer_[10]) << 8);
 
-    // A DLC > 8 means the bytes we matched as a header are almost certainly
-    // garbage that happened to alias the sync sequence. Drop one byte and
-    // resync rather than consuming an invalid frame.
-    if (can_length > CAN_MAX_DLC) {
+    if (data_length > MAX_REASONABLE_DATA_LENGTH) {
+      // The prefix we matched is almost certainly garbage that happened to
+      // alias the sync bytes. Drop one byte and resync.
       buffer_.erase(buffer_.begin());
       dropped_bytes_ += 1;
       continue;
     }
 
-    const size_t total_frame_size =
-      HEADER.size() + 5 + timestamp_size + frame_id_byte_length + can_length;
-
-    if (buffer_.size() < total_frame_size) {
-      return std::nullopt;
+    const size_t total_size = HEADER_SIZE + data_length;
+    if (buffer_.size() < total_size) {
+      return std::nullopt;  // wait for the full message body
     }
 
-    const size_t can_id_start = HEADER.size() + 5 + timestamp_size;
+    switch (message_id) {
+      case MSG_ID_CAN_STREAM_DEPRECATED: {
+        if (!decodeCanStreamBody(buffer_.data() + HEADER_SIZE, data_length)) {
+          // Body was malformed somewhere past the first frame. Frames that
+          // did decode have already been queued. Count the rest as dropped.
+          dropped_bytes_ += data_length;
+        }
+        break;
+      }
+      case MSG_ID_HEARTBEAT:
+        heartbeats_seen_++;
+        if (verbose_) {
+          std::cout << "[AxiomaticFrameParser] heartbeat #" << heartbeats_seen_ << std::endl;
+        }
+        break;
+      case MSG_ID_STATUS_RESPONSE:
+        status_responses_seen_++;
+        if (verbose_) {
+          std::cout << "[AxiomaticFrameParser] status response #"
+                    << status_responses_seen_ << std::endl;
+        }
+        break;
+      case MSG_ID_CAN_FD_STREAM:
+        can_fd_messages_skipped_++;
+        if (verbose_) {
+          std::cout << "[AxiomaticFrameParser] CAN FD message skipped #"
+                    << can_fd_messages_skipped_ << " (FD unsupported)" << std::endl;
+        }
+        break;
+      default:
+        unknown_messages_skipped_++;
+        if (verbose_) {
+          std::cout << "[AxiomaticFrameParser] unknown message id=" << message_id
+                    << " #" << unknown_messages_skipped_ << std::endl;
+        }
+        break;
+    }
+
+    buffer_.erase(buffer_.begin(), buffer_.begin() + total_size);
+    // Next loop iteration drains pending_frames_ or parses the next message.
+  }
+}
+
+bool AxiomaticFrameParser::decodeCanStreamBody(const uint8_t * body, size_t body_len)
+{
+  size_t offset = 0;
+  while (offset < body_len) {
+    const uint8_t control = body[offset];
+
+    // Bit 7 = 1 indicates a Notification Frame, which is a fixed 5-byte
+    // record. We skip past it so the next iteration finds the following
+    // CAN frame.
+    if ((control & 0x80) != 0) {
+      constexpr size_t NOTIFICATION_FRAME_SIZE = 5;
+      if (offset + NOTIFICATION_FRAME_SIZE > body_len) {
+        return false;  // truncated
+      }
+      notification_frames_skipped_++;
+      if (verbose_) {
+        std::cout << "[AxiomaticFrameParser] notification frame skipped #"
+                  << notification_frames_skipped_ << std::endl;
+      }
+      offset += NOTIFICATION_FRAME_SIZE;
+      continue;
+    }
+
+    const size_t timestamp_size = (control & 0x60) >> 5;
+    const bool is_extended = (control & 0x10) != 0;
+    const size_t can_length = control & 0x0F;
+
+    if (can_length > CAN_MAX_DLC) {
+      return false;
+    }
+
+    const size_t id_size = is_extended ? 4 : 2;
+    const size_t frame_total = 1 + timestamp_size + id_size + can_length;
+    if (offset + frame_total > body_len) {
+      return false;
+    }
+
+    const size_t id_offset = offset + 1 + timestamp_size;
     canid_t can_id = 0;
-    for (size_t i = 0; i < frame_id_byte_length; ++i) {
-      can_id |= static_cast<canid_t>(buffer_[can_id_start + i]) << (i * 8);
+    for (size_t i = 0; i < id_size; ++i) {
+      can_id |= static_cast<canid_t>(body[id_offset + i]) << (i * 8);
     }
-    const size_t can_data_start = can_id_start + frame_id_byte_length;
 
+    const size_t data_offset = id_offset + id_size;
     std::array<unsigned char, CAN_MAX_DLC> can_data{};
-    std::copy_n(buffer_.begin() + can_data_start, can_length, can_data.begin());
+    std::copy_n(body + data_offset, can_length, can_data.begin());
 
     polymath::socketcan::CanFrame frame;
     if (is_extended) {
@@ -113,9 +197,10 @@ std::optional<polymath::socketcan::CanFrame> AxiomaticFrameParser::tryParseFrame
     frame.set_len(static_cast<unsigned char>(can_length));
     frame.set_data(can_data);
 
-    buffer_.erase(buffer_.begin(), buffer_.begin() + total_frame_size);
-    return frame;
+    pending_frames_.push_back(frame);
+    offset += frame_total;
   }
+  return true;
 }
 
 }  // namespace can

--- a/axiomatic_adapter/src/axiomatic_frame_parser.cpp
+++ b/axiomatic_adapter/src/axiomatic_frame_parser.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "axiomatic_adapter/axiomatic_frame_parser.hpp"
+
+#include <linux/can.h>
+
+#include <algorithm>
+#include <iterator>
+
+namespace polymath
+{
+namespace can
+{
+
+void AxiomaticFrameParser::append(const uint8_t * data, size_t len)
+{
+  if (data == nullptr || len == 0) {
+    return;
+  }
+  buffer_.insert(buffer_.end(), data, data + len);
+}
+
+void AxiomaticFrameParser::reset()
+{
+  buffer_.clear();
+}
+
+std::optional<polymath::socketcan::CanFrame> AxiomaticFrameParser::tryParseFrame()
+{
+  // Header(7) + reserved(2) + length(2) + control(1) = 12 bytes before any
+  // variable-length fields. We need at least this much to decode the control byte.
+  constexpr size_t MIN_PREFIX_BYTES = HEADER.size() + 5;
+
+  while (true) {
+    // Locate the sync header. Anything before it is garbage to be skipped.
+    auto header_it = std::search(buffer_.begin(), buffer_.end(), HEADER.begin(), HEADER.end());
+
+    if (header_it == buffer_.end()) {
+      // No header in buffer. The tail may still hold the start of a header
+      // that will arrive in the next read, so keep up to HEADER.size()-1 bytes.
+      size_t keep = std::min(buffer_.size(), HEADER.size() - 1);
+      size_t drop = buffer_.size() - keep;
+      if (drop > 0) {
+        buffer_.erase(buffer_.begin(), buffer_.begin() + drop);
+        dropped_bytes_ += drop;
+      }
+      return std::nullopt;
+    }
+
+    if (header_it != buffer_.begin()) {
+      size_t drop = static_cast<size_t>(std::distance(buffer_.begin(), header_it));
+      buffer_.erase(buffer_.begin(), header_it);
+      dropped_bytes_ += drop;
+    }
+
+    if (buffer_.size() < MIN_PREFIX_BYTES) {
+      return std::nullopt;
+    }
+
+    // Decode the control byte (byte 11): bits 6-5 = timestamp size, bit 4 =
+    // extended ID flag, bits 3-0 = DLC. We derive the total frame size from
+    // these fields directly (rather than the message_length at bytes 9-10),
+    // so framing and per-field decoding can never disagree.
+    const uint8_t control_byte = buffer_[11];
+    const size_t timestamp_size = (control_byte & 0x60) >> 5;
+    const bool is_extended = (control_byte & 0x10) != 0;
+    const size_t can_length = control_byte & 0x0F;
+    const size_t frame_id_byte_length = is_extended ? 4 : 2;
+
+    // A DLC > 8 means the bytes we matched as a header are almost certainly
+    // garbage that happened to alias the sync sequence. Drop one byte and
+    // resync rather than consuming an invalid frame.
+    if (can_length > CAN_MAX_DLC) {
+      buffer_.erase(buffer_.begin());
+      dropped_bytes_ += 1;
+      continue;
+    }
+
+    const size_t total_frame_size =
+      HEADER.size() + 5 + timestamp_size + frame_id_byte_length + can_length;
+
+    if (buffer_.size() < total_frame_size) {
+      return std::nullopt;
+    }
+
+    const size_t can_id_start = HEADER.size() + 5 + timestamp_size;
+    canid_t can_id = 0;
+    for (size_t i = 0; i < frame_id_byte_length; ++i) {
+      can_id |= static_cast<canid_t>(buffer_[can_id_start + i]) << (i * 8);
+    }
+    const size_t can_data_start = can_id_start + frame_id_byte_length;
+
+    std::array<unsigned char, CAN_MAX_DLC> can_data{};
+    std::copy_n(buffer_.begin() + can_data_start, can_length, can_data.begin());
+
+    polymath::socketcan::CanFrame frame;
+    if (is_extended) {
+      frame.set_id_as_extended();
+    }
+    frame.set_can_id(can_id);
+    frame.set_len(static_cast<unsigned char>(can_length));
+    frame.set_data(can_data);
+
+    buffer_.erase(buffer_.begin(), buffer_.begin() + total_frame_size);
+    return frame;
+  }
+}
+
+}  // namespace can
+}  // namespace polymath

--- a/axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp
+++ b/axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp
@@ -105,7 +105,7 @@ void AxiomaticSocketcanBridge::socketcanReceiveCallback(std::unique_ptr<const po
   }
 
   auto result = axiomatic_adapter_.send(frame_copy);
-  if (!result) {
+  if (result) {
     std::cerr << "[SocketCAN RX] Failed to send CAN frame with message: " << *result << std::endl;
   }
 }
@@ -128,7 +128,7 @@ void AxiomaticSocketcanBridge::ethcanReceiveCallback(std::unique_ptr<const polym
   }
 
   auto result = socketcan_adapter_.send(frame_copy);
-  if (!result) {
+  if (result) {
     std::cerr << "[EthCAN RX] Failed to send CAN frame with message: " << *result << std::endl;
   }
 }

--- a/axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp
+++ b/axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp
@@ -25,7 +25,12 @@ namespace can
 AxiomaticSocketcanBridge::AxiomaticSocketcanBridge(
   const std::string & can_interface_name, const std::string & ip, const std::string & port, bool verbose)
 : socketcan_adapter_(can_interface_name)
-, axiomatic_adapter_(ip, port, std::bind(&AxiomaticSocketcanBridge::ethcanReceiveCallback, this, std::placeholders::_1))
+, axiomatic_adapter_(
+    ip, port,
+    std::bind(&AxiomaticSocketcanBridge::ethcanReceiveCallback, this, std::placeholders::_1),
+    [](polymath::can::AxiomaticAdapter::socket_error_string_t /*error*/) { /* no-op */ },
+    polymath::can::AxiomaticAdapter::DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS,
+    verbose)
 , verbose_(verbose)
 {
   socketcan_adapter_.setOnReceiveCallback(

--- a/axiomatic_adapter/test/axiomatic_adapter_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_adapter_test.cpp
@@ -32,8 +32,6 @@ using polymath::socketcan::CanFrame;
 
 // NOTE: These tests were written to run on hq0-robot04 with the in office CAN setup
 // NOTE: these tests leverage the socketcan adapter to act as a "secondary device" transmitting messages
-// NOTE: the first run may fail. This is due to an issue with the Axiomatic adapter that causes just the first message
-//       read to fail.
 TEST_CASE("AxiomaticAdapter tests", "[AxiomaticAdapter]")
 {
   SECTION("Constructor and destructor")

--- a/axiomatic_adapter/test/axiomatic_concurrent_io_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_concurrent_io_test.cpp
@@ -1,0 +1,234 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Concurrent-IO stress for AxiomaticAdapter. The Phase 3 refactor serializes
+// send and receive through a boost::asio::strand running on a single io
+// worker thread; these tests stand up a localhost peer that both reads our
+// outbound bytes and writes inbound CAN-Stream messages, then hammers send()
+// from one thread while the reception thread delivers frames via callback.
+// Should be run with ThreadSanitizer (-fsanitize=thread) to validate.
+
+#include "axiomatic_adapter/axiomatic_adapter.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>  // v3
+#else
+  #include <catch2/catch.hpp>  // v2
+#endif
+
+#include "axiomatic_adapter/axiomatic_frame_parser.hpp"
+#include "socketcan_adapter/can_frame.hpp"
+
+using polymath::can::AxiomaticAdapter;
+using polymath::can::AxiomaticFrameParser;
+using polymath::socketcan::CanFrame;
+
+namespace
+{
+
+// Build one CAN Stream message wrapping a single CAN frame. Used by the
+// echo-peer below to inject inbound frames the adapter must parse.
+std::vector<uint8_t> encodeCanStream(uint32_t can_id, std::vector<uint8_t> payload)
+{
+  const size_t id_size = 2;             // standard ID
+  const size_t timestamp_size = 2;
+  const uint16_t data_length = static_cast<uint16_t>(1 + timestamp_size + id_size + payload.size());
+
+  std::vector<uint8_t> bytes;
+  for (auto b : AxiomaticFrameParser::SYNC_PREFIX) {
+    bytes.push_back(b);
+  }
+  bytes.push_back(static_cast<uint8_t>(AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED >> 8) & 0xFF));
+  bytes.push_back(0x00);  // Message Version
+  bytes.push_back(static_cast<uint8_t>(data_length & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((data_length >> 8) & 0xFF));
+
+  const uint8_t control = static_cast<uint8_t>(
+    ((timestamp_size & 0x3) << 5) | (payload.size() & 0x0F));
+  bytes.push_back(control);
+  bytes.push_back(0xAB);
+  bytes.push_back(0xCD);
+  bytes.push_back(static_cast<uint8_t>(can_id & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((can_id >> 8) & 0xFF));
+  bytes.insert(bytes.end(), payload.begin(), payload.end());
+  return bytes;
+}
+
+// Peer that accepts one connection, drains incoming bytes in one thread, and
+// writes a steady stream of CAN-Stream messages in another. Stops on demand.
+class PeerEchoServer
+{
+public:
+  PeerEchoServer()
+  : io_context_()
+  , acceptor_(io_context_, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 0))
+  {
+    port_ = acceptor_.local_endpoint().port();
+  }
+
+  uint16_t port() const { return port_; }
+
+  void start()
+  {
+    accept_thread_ = std::thread([this]() {
+      boost::system::error_code ec;
+      acceptor_.accept(peer_socket_, ec);
+      if (ec) return;
+      accepted_ = true;
+
+      // Reader: drain whatever the adapter writes.
+      reader_thread_ = std::thread([this]() {
+        std::vector<uint8_t> buf(2048);
+        while (!stop_) {
+          boost::system::error_code rec;
+          size_t n = peer_socket_.read_some(boost::asio::buffer(buf), rec);
+          if (rec) break;
+          bytes_read_ += n;
+        }
+      });
+
+      // Writer: emit a tiny CAN-Stream message every ~500us.
+      writer_thread_ = std::thread([this]() {
+        uint32_t counter = 0;
+        while (!stop_) {
+          auto msg = encodeCanStream(0x300 + (counter & 0xFF), {static_cast<uint8_t>(counter)});
+          boost::system::error_code wec;
+          boost::asio::write(peer_socket_, boost::asio::buffer(msg), wec);
+          if (wec) break;
+          counter++;
+          std::this_thread::sleep_for(std::chrono::microseconds(500));
+        }
+      });
+    });
+  }
+
+  void stop()
+  {
+    stop_ = true;
+    boost::system::error_code ignored;
+    acceptor_.close(ignored);
+    if (peer_socket_.is_open()) {
+      peer_socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored);
+      peer_socket_.close(ignored);
+    }
+    if (writer_thread_.joinable()) writer_thread_.join();
+    if (reader_thread_.joinable()) reader_thread_.join();
+    if (accept_thread_.joinable()) accept_thread_.join();
+  }
+
+  ~PeerEchoServer() { stop(); }
+
+  bool accepted() const { return accepted_; }
+  size_t bytes_read() const { return bytes_read_; }
+
+private:
+  boost::asio::io_context io_context_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  boost::asio::ip::tcp::socket peer_socket_{io_context_};
+  uint16_t port_{0};
+
+  std::atomic<bool> stop_{false};
+  std::atomic<bool> accepted_{false};
+  std::atomic<size_t> bytes_read_{0};
+
+  std::thread accept_thread_;
+  std::thread reader_thread_;
+  std::thread writer_thread_;
+};
+
+}  // namespace
+
+TEST_CASE("AxiomaticAdapter: send hammers and reception loop run concurrently",
+          "[AxiomaticAdapter][concurrency]")
+{
+  PeerEchoServer server;
+  server.start();
+
+  std::atomic<uint64_t> frames_received{0};
+  std::atomic<uint64_t> errors_seen{0};
+
+  AxiomaticAdapter adapter(
+    "127.0.0.1", std::to_string(server.port()),
+    [&frames_received](std::unique_ptr<const CanFrame> frame) {
+      if (frame) frames_received++;
+    },
+    [&errors_seen](AxiomaticAdapter::socket_error_string_t /*err*/) {
+      errors_seen++;
+    });
+
+  REQUIRE(adapter.openSocket());
+  REQUIRE(adapter.startReceptionThread());
+
+  // Spin a sender thread for the duration of the test.
+  std::atomic<bool> stop_sender{false};
+  std::atomic<uint64_t> sends_attempted{0};
+  std::atomic<uint64_t> sends_failed{0};
+
+  std::thread sender([&]() {
+    CanFrame frame;
+    frame.set_can_id(0x123);
+    frame.set_len(4);
+    std::array<unsigned char, CAN_MAX_DLC> data = {0xDE, 0xAD, 0xBE, 0xEF};
+    frame.set_data(data);
+    while (!stop_sender) {
+      auto err = adapter.send(frame);
+      sends_attempted++;
+      if (err) sends_failed++;
+    }
+  });
+
+  // Run for a short fixed time. Long enough to exercise the race window but
+  // short enough not to dominate CI.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  stop_sender = true;
+  sender.join();
+
+  adapter.joinReceptionThread();
+  adapter.closeSocket();
+  server.stop();
+
+  REQUIRE(sends_attempted > 100);    // sanity: the loop actually ran
+  REQUIRE(sends_failed == 0);
+  REQUIRE(frames_received > 0);      // peer was writing; receive chain delivered them
+  REQUIRE(server.bytes_read() > 0);  // our sends made it to the wire
+}
+
+TEST_CASE("AxiomaticAdapter: TCP_NODELAY is set on openSocket", "[AxiomaticAdapter][nodelay]")
+{
+  // The setter is non-fatal on failure, so we cannot REQUIRE it from outside
+  // -- but we can verify that an open + close cycle does not log to stderr
+  // and that the socket reaches OPEN state, which means set_option succeeded
+  // (errors are non-fatal but the option call only runs after a successful
+  // connect).
+  PeerEchoServer server;
+  server.start();
+
+  AxiomaticAdapter adapter("127.0.0.1", std::to_string(server.port()));
+  REQUIRE(adapter.openSocket());
+  REQUIRE(adapter.get_socket_state() == polymath::can::TCPSocketState::OPEN);
+  REQUIRE(adapter.closeSocket());
+  REQUIRE(adapter.get_socket_state() == polymath::can::TCPSocketState::CLOSED);
+
+  server.stop();
+}

--- a/axiomatic_adapter/test/axiomatic_frame_parser_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_frame_parser_test.cpp
@@ -33,50 +33,112 @@ using polymath::socketcan::IdType;
 namespace
 {
 
-// Build the Axiomatic wire encoding for a single CAN frame.
-std::vector<uint8_t> encodeFrame(
-  uint32_t can_id,
-  const std::vector<uint8_t> & data,
-  bool is_extended,
-  size_t timestamp_size = 2)
+struct CanFrameSpec
 {
-  std::vector<uint8_t> bytes;
-  // Header
-  for (auto b : AxiomaticFrameParser::HEADER) {
-    bytes.push_back(b);
-  }
-  // Two reserved bytes
-  bytes.push_back(0x00);
-  bytes.push_back(0x00);
+  uint32_t can_id;
+  std::vector<uint8_t> data;
+  bool is_extended{false};
+  size_t timestamp_size{2};  // bits 6-5 of control byte; valid values 0..3
+};
 
-  const size_t id_len = is_extended ? 4 : 2;
-  const size_t message_length = 1 + timestamp_size + id_len + data.size();
-  bytes.push_back(static_cast<uint8_t>(message_length & 0xFF));
-  bytes.push_back(static_cast<uint8_t>((message_length >> 8) & 0xFF));
-
+// Encode a single in-message frame (control byte + timestamp + id + data).
+std::vector<uint8_t> encodeCanFrameInBody(const CanFrameSpec & spec)
+{
+  std::vector<uint8_t> out;
+  const size_t id_size = spec.is_extended ? 4 : 2;
   const uint8_t control =
-    static_cast<uint8_t>(((timestamp_size & 0x3) << 5) | (is_extended ? (1 << 4) : 0) |
-                         (data.size() & 0x0F));
-  bytes.push_back(control);
-
-  // Timestamp bytes (value does not matter to the parser).
-  for (size_t i = 0; i < timestamp_size; ++i) {
-    bytes.push_back(0xAB);
+    static_cast<uint8_t>(((spec.timestamp_size & 0x3) << 5) |
+                         (spec.is_extended ? (1 << 4) : 0) |
+                         (spec.data.size() & 0x0F));
+  out.push_back(control);
+  for (size_t i = 0; i < spec.timestamp_size; ++i) {
+    out.push_back(0xAB);
   }
-
-  // CAN ID, little-endian.
-  for (size_t i = 0; i < id_len; ++i) {
-    bytes.push_back(static_cast<uint8_t>((can_id >> (i * 8)) & 0xFF));
+  for (size_t i = 0; i < id_size; ++i) {
+    out.push_back(static_cast<uint8_t>((spec.can_id >> (i * 8)) & 0xFF));
   }
+  out.insert(out.end(), spec.data.begin(), spec.data.end());
+  return out;
+}
 
-  // Data.
-  bytes.insert(bytes.end(), data.begin(), data.end());
-  return bytes;
+// Encode a 5-byte Notification Frame placeholder (control bit 7 = 1).
+std::vector<uint8_t> encodeNotificationFrameInBody()
+{
+  return {0x80, 0x00, 0x00, 0x00, 0x00};
+}
+
+// Wrap an arbitrary message body in the 11-byte Axiomatic envelope.
+std::vector<uint8_t> encodeMessage(uint16_t message_id, const std::vector<uint8_t> & body)
+{
+  std::vector<uint8_t> out;
+  for (auto b : AxiomaticFrameParser::SYNC_PREFIX) {
+    out.push_back(b);
+  }
+  out.push_back(static_cast<uint8_t>(message_id & 0xFF));
+  out.push_back(static_cast<uint8_t>((message_id >> 8) & 0xFF));
+  out.push_back(0x00);  // Message Version
+  const uint16_t data_length = static_cast<uint16_t>(body.size());
+  out.push_back(static_cast<uint8_t>(data_length & 0xFF));
+  out.push_back(static_cast<uint8_t>((data_length >> 8) & 0xFF));
+  out.insert(out.end(), body.begin(), body.end());
+  return out;
+}
+
+// Convenience: a CAN Stream message carrying a single CAN frame.
+std::vector<uint8_t> encodeCanStreamMessage(const CanFrameSpec & spec)
+{
+  return encodeMessage(
+    AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED, encodeCanFrameInBody(spec));
+}
+
+// CAN Stream carrying an arbitrary sequence of CAN and Notification frames.
+// items: positive value => index into `frames`; -1 => insert a Notification.
+std::vector<uint8_t> encodeCanStreamMixed(
+  const std::vector<CanFrameSpec> & frames,
+  const std::vector<int> & layout)
+{
+  std::vector<uint8_t> body;
+  for (int item : layout) {
+    if (item < 0) {
+      auto n = encodeNotificationFrameInBody();
+      body.insert(body.end(), n.begin(), n.end());
+    } else {
+      auto f = encodeCanFrameInBody(frames[item]);
+      body.insert(body.end(), f.begin(), f.end());
+    }
+  }
+  return encodeMessage(AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED, body);
+}
+
+std::vector<uint8_t> encodeHeartbeatMessage()
+{
+  // The Axiomatic Heartbeat has a payload describing converter health, but the
+  // parser does not introspect it -- any payload of declared length works.
+  std::vector<uint8_t> body(8, 0x00);
+  return encodeMessage(AxiomaticFrameParser::MSG_ID_HEARTBEAT, body);
+}
+
+std::vector<uint8_t> encodeStatusResponseMessage()
+{
+  std::vector<uint8_t> body(4, 0xAA);
+  return encodeMessage(AxiomaticFrameParser::MSG_ID_STATUS_RESPONSE, body);
+}
+
+std::vector<uint8_t> encodeCanFdMessage()
+{
+  std::vector<uint8_t> body(16, 0x55);
+  return encodeMessage(AxiomaticFrameParser::MSG_ID_CAN_FD_STREAM, body);
+}
+
+std::vector<uint8_t> encodeUnknownMessage(uint16_t id)
+{
+  std::vector<uint8_t> body(3, 0xEE);
+  return encodeMessage(id, body);
 }
 
 }  // namespace
 
-TEST_CASE("AxiomaticFrameParser: empty buffer returns nullopt", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: empty buffer", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
   REQUIRE_FALSE(parser.tryParseFrame().has_value());
@@ -84,11 +146,11 @@ TEST_CASE("AxiomaticFrameParser: empty buffer returns nullopt", "[AxiomaticFrame
   REQUIRE(parser.dropped_bytes() == 0);
 }
 
-TEST_CASE("AxiomaticFrameParser: single standard frame", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: single standard CAN frame in a CAN Stream message", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
   const std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04};
-  auto wire = encodeFrame(0x123, data, /*is_extended=*/false);
+  auto wire = encodeCanStreamMessage({0x123, data, false, 2});
 
   parser.append(wire.data(), wire.size());
   auto frame = parser.tryParseFrame();
@@ -101,16 +163,15 @@ TEST_CASE("AxiomaticFrameParser: single standard frame", "[AxiomaticFrameParser]
   for (size_t i = 0; i < data.size(); ++i) {
     REQUIRE(got[i] == data[i]);
   }
-  REQUIRE(parser.buffered_bytes() == 0);
   REQUIRE_FALSE(parser.tryParseFrame().has_value());
 }
 
-TEST_CASE("AxiomaticFrameParser: single extended frame", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: single extended CAN frame", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
   const std::vector<uint8_t> data = {0xAA, 0xBB, 0xCC};
   const uint32_t can_id = 0x1ABCDEF;
-  auto wire = encodeFrame(can_id, data, /*is_extended=*/true);
+  auto wire = encodeCanStreamMessage({can_id, data, true, 2});
 
   parser.append(wire.data(), wire.size());
   auto frame = parser.tryParseFrame();
@@ -119,17 +180,13 @@ TEST_CASE("AxiomaticFrameParser: single extended frame", "[AxiomaticFrameParser]
   REQUIRE(frame->get_id_type() == IdType::EXTENDED);
   REQUIRE(frame->get_id() == can_id);
   REQUIRE(static_cast<size_t>(frame->get_len()) == data.size());
-  auto got = frame->get_data();
-  for (size_t i = 0; i < data.size(); ++i) {
-    REQUIRE(got[i] == data[i]);
-  }
 }
 
-TEST_CASE("AxiomaticFrameParser: coalesced frames in one append", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: two coalesced CAN Stream messages, one frame each", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
-  auto a = encodeFrame(0x100, {0x11, 0x22}, false);
-  auto b = encodeFrame(0x200, {0x33, 0x44, 0x55, 0x66}, false);
+  auto a = encodeCanStreamMessage({0x100, {0x11, 0x22}, false, 2});
+  auto b = encodeCanStreamMessage({0x200, {0x33, 0x44, 0x55, 0x66}, false, 2});
 
   std::vector<uint8_t> combined = a;
   combined.insert(combined.end(), b.begin(), b.end());
@@ -138,43 +195,164 @@ TEST_CASE("AxiomaticFrameParser: coalesced frames in one append", "[AxiomaticFra
   auto f1 = parser.tryParseFrame();
   REQUIRE(f1.has_value());
   REQUIRE(f1->get_id() == 0x100u);
-  REQUIRE(f1->get_len() == 2);
 
   auto f2 = parser.tryParseFrame();
   REQUIRE(f2.has_value());
   REQUIRE(f2->get_id() == 0x200u);
-  REQUIRE(f2->get_len() == 4);
 
-  REQUIRE(parser.buffered_bytes() == 0);
   REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.buffered_bytes() == 0);
 }
 
-TEST_CASE("AxiomaticFrameParser: frame split across two appends", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: CAN Stream message carrying THREE packed CAN frames", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
-  auto wire = encodeFrame(0x321, {0x01, 0x02, 0x03}, false);
+  std::vector<CanFrameSpec> specs = {
+    {0x101, {0xA1}, false, 2},
+    {0x102, {0xB1, 0xB2}, false, 2},
+    {0x103, {0xC1, 0xC2, 0xC3, 0xC4}, false, 2},
+  };
+  auto wire = encodeCanStreamMixed(specs, {0, 1, 2});
+
+  parser.append(wire.data(), wire.size());
+
+  auto f1 = parser.tryParseFrame();
+  REQUIRE(f1.has_value());
+  REQUIRE(f1->get_id() == 0x101u);
+  REQUIRE(f1->get_len() == 1);
+
+  auto f2 = parser.tryParseFrame();
+  REQUIRE(f2.has_value());
+  REQUIRE(f2->get_id() == 0x102u);
+  REQUIRE(f2->get_len() == 2);
+
+  auto f3 = parser.tryParseFrame();
+  REQUIRE(f3.has_value());
+  REQUIRE(f3->get_id() == 0x103u);
+  REQUIRE(f3->get_len() == 4);
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.notification_frames_skipped() == 0);
+}
+
+TEST_CASE("Parser: CAN Stream with CAN + Notification + CAN", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  std::vector<CanFrameSpec> specs = {
+    {0x010, {0x01}, false, 2},
+    {0x020, {0x02, 0x03}, false, 2},
+  };
+  auto wire = encodeCanStreamMixed(specs, {0, -1, 1});
+
+  parser.append(wire.data(), wire.size());
+
+  auto f1 = parser.tryParseFrame();
+  REQUIRE(f1.has_value());
+  REQUIRE(f1->get_id() == 0x010u);
+
+  auto f2 = parser.tryParseFrame();
+  REQUIRE(f2.has_value());
+  REQUIRE(f2->get_id() == 0x020u);
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.notification_frames_skipped() == 1);
+}
+
+TEST_CASE("Parser: heartbeat alone returns nullopt and counts", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeHeartbeatMessage();
+  parser.append(wire.data(), wire.size());
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.heartbeats_seen() == 1);
+  REQUIRE(parser.dropped_bytes() == 0);
+  REQUIRE(parser.buffered_bytes() == 0);
+}
+
+TEST_CASE("Parser: heartbeat followed by CAN Stream still delivers the frame",
+          "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto hb = encodeHeartbeatMessage();
+  auto cf = encodeCanStreamMessage({0x321, {0xDE, 0xAD}, false, 2});
+
+  std::vector<uint8_t> combined = hb;
+  combined.insert(combined.end(), cf.begin(), cf.end());
+  parser.append(combined.data(), combined.size());
+
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x321u);
+  REQUIRE(parser.heartbeats_seen() == 1);
+  REQUIRE(parser.dropped_bytes() == 0);
+}
+
+TEST_CASE("Parser: status response skipped cleanly", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeStatusResponseMessage();
+  parser.append(wire.data(), wire.size());
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.status_responses_seen() == 1);
+}
+
+TEST_CASE("Parser: CAN FD stream skipped cleanly", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeCanFdMessage();
+  parser.append(wire.data(), wire.size());
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.can_fd_messages_skipped() == 1);
+}
+
+TEST_CASE("Parser: unknown message id skipped cleanly", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeUnknownMessage(99);
+  parser.append(wire.data(), wire.size());
+
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.unknown_messages_skipped() == 1);
+}
+
+TEST_CASE("Parser: frame split across two appends", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeCanStreamMessage({0x456, {0x77, 0x88, 0x99}, false, 2});
 
   const size_t split = wire.size() / 2;
   parser.append(wire.data(), split);
   REQUIRE_FALSE(parser.tryParseFrame().has_value());
-  REQUIRE(parser.buffered_bytes() == split);
 
   parser.append(wire.data() + split, wire.size() - split);
   auto frame = parser.tryParseFrame();
   REQUIRE(frame.has_value());
-  REQUIRE(frame->get_id() == 0x321u);
-  REQUIRE(parser.buffered_bytes() == 0);
+  REQUIRE(frame->get_id() == 0x456u);
 }
 
-TEST_CASE("AxiomaticFrameParser: garbage prefix is skipped", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: heartbeat split across two appends", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
-  std::vector<uint8_t> wire;
-  // Garbage that does not contain the header.
-  for (uint8_t b : {0x00, 0xFF, 0x01, 0x02, 0x42}) {
-    wire.push_back(b);
-  }
-  auto frame_bytes = encodeFrame(0x555, {0xDE, 0xAD}, false);
+  auto wire = encodeHeartbeatMessage();
+
+  parser.append(wire.data(), 7);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.heartbeats_seen() == 0);
+
+  parser.append(wire.data() + 7, wire.size() - 7);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.heartbeats_seen() == 1);
+}
+
+TEST_CASE("Parser: garbage prefix is skipped, frame still delivered",
+          "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  std::vector<uint8_t> wire = {0x00, 0xFF, 0x01, 0x02, 0x42};
+  auto frame_bytes = encodeCanStreamMessage({0x555, {0xDE, 0xAD}, false, 2});
   wire.insert(wire.end(), frame_bytes.begin(), frame_bytes.end());
 
   parser.append(wire.data(), wire.size());
@@ -184,54 +362,32 @@ TEST_CASE("AxiomaticFrameParser: garbage prefix is skipped", "[AxiomaticFramePar
   REQUIRE(parser.dropped_bytes() == 5);
 }
 
-TEST_CASE("AxiomaticFrameParser: header split across appends", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: DLC 0 edge case", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
-  auto wire = encodeFrame(0x456, {0x77, 0x88}, false);
-
-  // First append contains only the first 4 header bytes ("AXIO").
-  parser.append(wire.data(), 4);
-  REQUIRE_FALSE(parser.tryParseFrame().has_value());
-
-  // Second append delivers the rest.
-  parser.append(wire.data() + 4, wire.size() - 4);
-  auto frame = parser.tryParseFrame();
-  REQUIRE(frame.has_value());
-  REQUIRE(frame->get_id() == 0x456u);
-  REQUIRE(parser.dropped_bytes() == 0);
-}
-
-TEST_CASE("AxiomaticFrameParser: DLC 0 edge case", "[AxiomaticFrameParser]")
-{
-  AxiomaticFrameParser parser;
-  auto wire = encodeFrame(0x010, {}, false);
+  auto wire = encodeCanStreamMessage({0x010, {}, false, 2});
   parser.append(wire.data(), wire.size());
 
   auto frame = parser.tryParseFrame();
   REQUIRE(frame.has_value());
   REQUIRE(frame->get_len() == 0);
   REQUIRE(frame->get_id() == 0x010u);
-  REQUIRE(parser.buffered_bytes() == 0);
 }
 
-TEST_CASE("AxiomaticFrameParser: DLC 8 edge case", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: DLC 8 edge case", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
   const std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-  auto wire = encodeFrame(0x7FF, data, false);
+  auto wire = encodeCanStreamMessage({0x7FF, data, false, 2});
   parser.append(wire.data(), wire.size());
 
   auto frame = parser.tryParseFrame();
   REQUIRE(frame.has_value());
   REQUIRE(frame->get_len() == 8);
   REQUIRE(frame->get_id() == 0x7FFu);
-  auto got = frame->get_data();
-  for (size_t i = 0; i < data.size(); ++i) {
-    REQUIRE(got[i] == data[i]);
-  }
 }
 
-TEST_CASE("AxiomaticFrameParser: reset clears state", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: reset clears state", "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
   parser.append(reinterpret_cast<const uint8_t *>("garbage"), 7);
@@ -240,24 +396,51 @@ TEST_CASE("AxiomaticFrameParser: reset clears state", "[AxiomaticFrameParser]")
   REQUIRE(parser.buffered_bytes() == 0);
 }
 
-TEST_CASE("AxiomaticFrameParser: many coalesced frames stress", "[AxiomaticFrameParser]")
+TEST_CASE("Parser: heartbeat + 3-frame CAN Stream + heartbeat coalesced",
+          "[AxiomaticFrameParser]")
 {
   AxiomaticFrameParser parser;
-  constexpr size_t kFrames = 64;
+  std::vector<CanFrameSpec> specs = {
+    {0x701, {0xA1, 0xA2}, false, 2},
+    {0x702, {0xB1, 0xB2, 0xB3}, false, 2},
+    {0x703, {0xC1}, false, 2},
+  };
+  auto hb1 = encodeHeartbeatMessage();
+  auto can = encodeCanStreamMixed(specs, {0, 1, 2});
+  auto hb2 = encodeHeartbeatMessage();
+
+  std::vector<uint8_t> combined;
+  combined.insert(combined.end(), hb1.begin(), hb1.end());
+  combined.insert(combined.end(), can.begin(), can.end());
+  combined.insert(combined.end(), hb2.begin(), hb2.end());
+  parser.append(combined.data(), combined.size());
+
+  std::vector<uint32_t> got_ids;
+  while (auto f = parser.tryParseFrame()) {
+    got_ids.push_back(f->get_id());
+  }
+  REQUIRE(got_ids == std::vector<uint32_t>{0x701, 0x702, 0x703});
+  REQUIRE(parser.heartbeats_seen() == 2);
+  REQUIRE(parser.dropped_bytes() == 0);
+}
+
+TEST_CASE("Parser: many coalesced single-frame messages stress",
+          "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  constexpr size_t kMessages = 64;
   std::vector<uint8_t> blob;
-  for (size_t i = 0; i < kFrames; ++i) {
-    auto f = encodeFrame(0x100 + i, {static_cast<uint8_t>(i)}, false);
-    blob.insert(blob.end(), f.begin(), f.end());
+  for (size_t i = 0; i < kMessages; ++i) {
+    auto m = encodeCanStreamMessage({static_cast<uint32_t>(0x100 + i),
+                                     {static_cast<uint8_t>(i)}, false, 2});
+    blob.insert(blob.end(), m.begin(), m.end());
   }
   parser.append(blob.data(), blob.size());
 
-  for (size_t i = 0; i < kFrames; ++i) {
+  for (size_t i = 0; i < kMessages; ++i) {
     auto frame = parser.tryParseFrame();
     REQUIRE(frame.has_value());
     REQUIRE(frame->get_id() == static_cast<uint32_t>(0x100 + i));
-    REQUIRE(frame->get_len() == 1);
-    REQUIRE(frame->get_data()[0] == static_cast<uint8_t>(i));
   }
   REQUIRE_FALSE(parser.tryParseFrame().has_value());
-  REQUIRE(parser.buffered_bytes() == 0);
 }

--- a/axiomatic_adapter/test/axiomatic_frame_parser_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_frame_parser_test.cpp
@@ -1,0 +1,263 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "axiomatic_adapter/axiomatic_frame_parser.hpp"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>  // v3
+#else
+  #include <catch2/catch.hpp>  // v2
+#endif
+
+#include "socketcan_adapter/can_frame.hpp"
+
+using polymath::can::AxiomaticFrameParser;
+using polymath::socketcan::CanFrame;
+using polymath::socketcan::IdType;
+
+namespace
+{
+
+// Build the Axiomatic wire encoding for a single CAN frame.
+std::vector<uint8_t> encodeFrame(
+  uint32_t can_id,
+  const std::vector<uint8_t> & data,
+  bool is_extended,
+  size_t timestamp_size = 2)
+{
+  std::vector<uint8_t> bytes;
+  // Header
+  for (auto b : AxiomaticFrameParser::HEADER) {
+    bytes.push_back(b);
+  }
+  // Two reserved bytes
+  bytes.push_back(0x00);
+  bytes.push_back(0x00);
+
+  const size_t id_len = is_extended ? 4 : 2;
+  const size_t message_length = 1 + timestamp_size + id_len + data.size();
+  bytes.push_back(static_cast<uint8_t>(message_length & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((message_length >> 8) & 0xFF));
+
+  const uint8_t control =
+    static_cast<uint8_t>(((timestamp_size & 0x3) << 5) | (is_extended ? (1 << 4) : 0) |
+                         (data.size() & 0x0F));
+  bytes.push_back(control);
+
+  // Timestamp bytes (value does not matter to the parser).
+  for (size_t i = 0; i < timestamp_size; ++i) {
+    bytes.push_back(0xAB);
+  }
+
+  // CAN ID, little-endian.
+  for (size_t i = 0; i < id_len; ++i) {
+    bytes.push_back(static_cast<uint8_t>((can_id >> (i * 8)) & 0xFF));
+  }
+
+  // Data.
+  bytes.insert(bytes.end(), data.begin(), data.end());
+  return bytes;
+}
+
+}  // namespace
+
+TEST_CASE("AxiomaticFrameParser: empty buffer returns nullopt", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.buffered_bytes() == 0);
+  REQUIRE(parser.dropped_bytes() == 0);
+}
+
+TEST_CASE("AxiomaticFrameParser: single standard frame", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  const std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04};
+  auto wire = encodeFrame(0x123, data, /*is_extended=*/false);
+
+  parser.append(wire.data(), wire.size());
+  auto frame = parser.tryParseFrame();
+
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x123u);
+  REQUIRE(frame->get_id_type() == IdType::STANDARD);
+  REQUIRE(static_cast<size_t>(frame->get_len()) == data.size());
+  auto got = frame->get_data();
+  for (size_t i = 0; i < data.size(); ++i) {
+    REQUIRE(got[i] == data[i]);
+  }
+  REQUIRE(parser.buffered_bytes() == 0);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+}
+
+TEST_CASE("AxiomaticFrameParser: single extended frame", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  const std::vector<uint8_t> data = {0xAA, 0xBB, 0xCC};
+  const uint32_t can_id = 0x1ABCDEF;
+  auto wire = encodeFrame(can_id, data, /*is_extended=*/true);
+
+  parser.append(wire.data(), wire.size());
+  auto frame = parser.tryParseFrame();
+
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id_type() == IdType::EXTENDED);
+  REQUIRE(frame->get_id() == can_id);
+  REQUIRE(static_cast<size_t>(frame->get_len()) == data.size());
+  auto got = frame->get_data();
+  for (size_t i = 0; i < data.size(); ++i) {
+    REQUIRE(got[i] == data[i]);
+  }
+}
+
+TEST_CASE("AxiomaticFrameParser: coalesced frames in one append", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto a = encodeFrame(0x100, {0x11, 0x22}, false);
+  auto b = encodeFrame(0x200, {0x33, 0x44, 0x55, 0x66}, false);
+
+  std::vector<uint8_t> combined = a;
+  combined.insert(combined.end(), b.begin(), b.end());
+  parser.append(combined.data(), combined.size());
+
+  auto f1 = parser.tryParseFrame();
+  REQUIRE(f1.has_value());
+  REQUIRE(f1->get_id() == 0x100u);
+  REQUIRE(f1->get_len() == 2);
+
+  auto f2 = parser.tryParseFrame();
+  REQUIRE(f2.has_value());
+  REQUIRE(f2->get_id() == 0x200u);
+  REQUIRE(f2->get_len() == 4);
+
+  REQUIRE(parser.buffered_bytes() == 0);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+}
+
+TEST_CASE("AxiomaticFrameParser: frame split across two appends", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeFrame(0x321, {0x01, 0x02, 0x03}, false);
+
+  const size_t split = wire.size() / 2;
+  parser.append(wire.data(), split);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.buffered_bytes() == split);
+
+  parser.append(wire.data() + split, wire.size() - split);
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x321u);
+  REQUIRE(parser.buffered_bytes() == 0);
+}
+
+TEST_CASE("AxiomaticFrameParser: garbage prefix is skipped", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  std::vector<uint8_t> wire;
+  // Garbage that does not contain the header.
+  for (uint8_t b : {0x00, 0xFF, 0x01, 0x02, 0x42}) {
+    wire.push_back(b);
+  }
+  auto frame_bytes = encodeFrame(0x555, {0xDE, 0xAD}, false);
+  wire.insert(wire.end(), frame_bytes.begin(), frame_bytes.end());
+
+  parser.append(wire.data(), wire.size());
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x555u);
+  REQUIRE(parser.dropped_bytes() == 5);
+}
+
+TEST_CASE("AxiomaticFrameParser: header split across appends", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeFrame(0x456, {0x77, 0x88}, false);
+
+  // First append contains only the first 4 header bytes ("AXIO").
+  parser.append(wire.data(), 4);
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+
+  // Second append delivers the rest.
+  parser.append(wire.data() + 4, wire.size() - 4);
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x456u);
+  REQUIRE(parser.dropped_bytes() == 0);
+}
+
+TEST_CASE("AxiomaticFrameParser: DLC 0 edge case", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  auto wire = encodeFrame(0x010, {}, false);
+  parser.append(wire.data(), wire.size());
+
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_len() == 0);
+  REQUIRE(frame->get_id() == 0x010u);
+  REQUIRE(parser.buffered_bytes() == 0);
+}
+
+TEST_CASE("AxiomaticFrameParser: DLC 8 edge case", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  const std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  auto wire = encodeFrame(0x7FF, data, false);
+  parser.append(wire.data(), wire.size());
+
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_len() == 8);
+  REQUIRE(frame->get_id() == 0x7FFu);
+  auto got = frame->get_data();
+  for (size_t i = 0; i < data.size(); ++i) {
+    REQUIRE(got[i] == data[i]);
+  }
+}
+
+TEST_CASE("AxiomaticFrameParser: reset clears state", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  parser.append(reinterpret_cast<const uint8_t *>("garbage"), 7);
+  REQUIRE(parser.buffered_bytes() > 0);
+  parser.reset();
+  REQUIRE(parser.buffered_bytes() == 0);
+}
+
+TEST_CASE("AxiomaticFrameParser: many coalesced frames stress", "[AxiomaticFrameParser]")
+{
+  AxiomaticFrameParser parser;
+  constexpr size_t kFrames = 64;
+  std::vector<uint8_t> blob;
+  for (size_t i = 0; i < kFrames; ++i) {
+    auto f = encodeFrame(0x100 + i, {static_cast<uint8_t>(i)}, false);
+    blob.insert(blob.end(), f.begin(), f.end());
+  }
+  parser.append(blob.data(), blob.size());
+
+  for (size_t i = 0; i < kFrames; ++i) {
+    auto frame = parser.tryParseFrame();
+    REQUIRE(frame.has_value());
+    REQUIRE(frame->get_id() == static_cast<uint32_t>(0x100 + i));
+    REQUIRE(frame->get_len() == 1);
+    REQUIRE(frame->get_data()[0] == static_cast<uint8_t>(i));
+  }
+  REQUIRE_FALSE(parser.tryParseFrame().has_value());
+  REQUIRE(parser.buffered_bytes() == 0);
+}

--- a/axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp
@@ -134,12 +134,15 @@ void assertEncodingMatchesDlc(uint16_t can_id, const std::vector<uint8_t> & payl
 
   REQUIRE(bytes.size() >= expected_total);
 
-  // Header check.
-  for (size_t i = 0; i < AxiomaticFrameParser::HEADER.size(); ++i) {
-    REQUIRE(bytes[i] == AxiomaticFrameParser::HEADER[i]);
+  // 6-byte sync prefix.
+  for (size_t i = 0; i < AxiomaticFrameParser::SYNC_PREFIX.size(); ++i) {
+    REQUIRE(bytes[i] == AxiomaticFrameParser::SYNC_PREFIX[i]);
   }
-  // Reserved bytes.
-  REQUIRE(bytes[7] == 0x00);
+  // Message ID (bytes 6-7) must be the deprecated CAN Stream (= 1).
+  const uint16_t msg_id = static_cast<uint16_t>(bytes[6]) |
+                          (static_cast<uint16_t>(bytes[7]) << 8);
+  REQUIRE(msg_id == AxiomaticFrameParser::MSG_ID_CAN_STREAM_DEPRECATED);
+  // Message Version is currently always 0.
   REQUIRE(bytes[8] == 0x00);
 
   // Declared message_length must equal control(1) + timestamp(2) + id(2) + dlc.

--- a/axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp
+++ b/axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2025-present Polymath Robotics, Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These tests stand up a localhost TCP acceptor in-process, point an
+// AxiomaticAdapter at it, then assert that the bytes the adapter writes on
+// send() match the Axiomatic wire format -- specifically that the declared
+// message_length agrees with the actual number of payload bytes, regardless
+// of DLC.
+
+#include "axiomatic_adapter/axiomatic_adapter.hpp"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#if __has_include(<catch2/catch_all.hpp>)
+  #include <catch2/catch_all.hpp>  // v3
+#else
+  #include <catch2/catch.hpp>  // v2
+#endif
+
+#include "axiomatic_adapter/axiomatic_frame_parser.hpp"
+#include "socketcan_adapter/can_frame.hpp"
+
+using polymath::can::AxiomaticAdapter;
+using polymath::can::AxiomaticFrameParser;
+using polymath::socketcan::CanFrame;
+
+namespace
+{
+
+// Spins up a one-shot localhost acceptor that captures everything written by
+// the first client until the client disconnects or `max_bytes` is reached.
+class LoopbackServer
+{
+public:
+  LoopbackServer()
+  : io_context_()
+  , acceptor_(io_context_, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 0))
+  {
+    port_ = acceptor_.local_endpoint().port();
+  }
+
+  uint16_t port() const { return port_; }
+
+  // Blocks until a client connects and either disconnects or has sent
+  // `min_bytes`. Returns whatever was read.
+  std::vector<uint8_t> collect(size_t min_bytes, std::chrono::milliseconds timeout)
+  {
+    std::vector<uint8_t> out;
+    std::thread reader([&]() {
+      boost::asio::ip::tcp::socket peer(io_context_);
+      acceptor_.accept(peer);
+
+      std::array<uint8_t, 1024> buf{};
+      boost::system::error_code ec;
+      while (out.size() < min_bytes) {
+        size_t n = peer.read_some(boost::asio::buffer(buf), ec);
+        if (ec) {
+          break;
+        }
+        out.insert(out.end(), buf.data(), buf.data() + n);
+      }
+    });
+
+    if (reader.joinable()) {
+      // Detach if timeout elapses so the test does not hang on regression.
+      auto start = std::chrono::steady_clock::now();
+      while (out.size() < min_bytes &&
+             std::chrono::steady_clock::now() - start < timeout)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+      // Close the acceptor's pending side so read_some unblocks if the client
+      // is gone.
+      boost::system::error_code ec;
+      acceptor_.close(ec);
+      reader.join();
+    }
+    return out;
+  }
+
+private:
+  boost::asio::io_context io_context_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  uint16_t port_{0};
+};
+
+void assertEncodingMatchesDlc(uint16_t can_id, const std::vector<uint8_t> & payload)
+{
+  LoopbackServer server;
+  const std::string ip = "127.0.0.1";
+  const std::string port = std::to_string(server.port());
+
+  AxiomaticAdapter adapter(ip, port);
+  REQUIRE(adapter.openSocket());
+
+  // Issue the send from another thread; the server collects on this thread.
+  std::thread sender([&]() {
+    CanFrame frame;
+    frame.set_can_id(can_id);
+    frame.set_len(static_cast<unsigned char>(payload.size()));
+    std::array<unsigned char, CAN_MAX_DLC> data{};
+    for (size_t i = 0; i < payload.size(); ++i) {
+      data[i] = payload[i];
+    }
+    frame.set_data(data);
+    auto err = adapter.send(frame);
+    REQUIRE_FALSE(err.has_value());
+  });
+
+  // Total wire bytes: header(7) + reserved(2) + length(2) + message_length
+  // where message_length = control(1) + timestamp(2) + id_len(2 for standard) + dlc.
+  const size_t expected_total = 11 + 1 + 2 + 2 + payload.size();
+  auto bytes = server.collect(expected_total, std::chrono::milliseconds(500));
+  sender.join();
+  adapter.closeSocket();
+
+  REQUIRE(bytes.size() >= expected_total);
+
+  // Header check.
+  for (size_t i = 0; i < AxiomaticFrameParser::HEADER.size(); ++i) {
+    REQUIRE(bytes[i] == AxiomaticFrameParser::HEADER[i]);
+  }
+  // Reserved bytes.
+  REQUIRE(bytes[7] == 0x00);
+  REQUIRE(bytes[8] == 0x00);
+
+  // Declared message_length must equal control(1) + timestamp(2) + id(2) + dlc.
+  const uint16_t declared = static_cast<uint16_t>(bytes[9]) |
+                            (static_cast<uint16_t>(bytes[10]) << 8);
+  const uint16_t expected_declared = static_cast<uint16_t>(1 + 2 + 2 + payload.size());
+  REQUIRE(declared == expected_declared);
+
+  // Actual payload bytes after the 11-byte fixed prefix must equal declared.
+  REQUIRE((bytes.size() - 11) == declared);
+
+  // Payload data bytes match -- after control(1) + timestamp(2) + id(2) = 5 bytes
+  // past byte 11, so they start at offset 11 + 5 = 16.
+  for (size_t i = 0; i < payload.size(); ++i) {
+    REQUIRE(bytes[16 + i] == payload[i]);
+  }
+}
+
+}  // namespace
+
+TEST_CASE("AxiomaticAdapter::send encodes DLC 4 with matching length", "[AxiomaticAdapter][send]")
+{
+  assertEncodingMatchesDlc(0x123, {0x01, 0x02, 0x03, 0x04});
+}
+
+TEST_CASE("AxiomaticAdapter::send encodes DLC 0 with matching length", "[AxiomaticAdapter][send]")
+{
+  assertEncodingMatchesDlc(0x123, {});
+}
+
+TEST_CASE("AxiomaticAdapter::send encodes DLC 8 with matching length", "[AxiomaticAdapter][send]")
+{
+  assertEncodingMatchesDlc(0x123, {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88});
+}
+
+TEST_CASE("AxiomaticAdapter::send wire format round-trips through the parser", "[AxiomaticAdapter][send]")
+{
+  // The receive parser is the inverse of send(); verify they agree end-to-end.
+  LoopbackServer server;
+  const std::string ip = "127.0.0.1";
+  const std::string port = std::to_string(server.port());
+
+  AxiomaticAdapter adapter(ip, port);
+  REQUIRE(adapter.openSocket());
+
+  const std::vector<uint8_t> payload = {0xDE, 0xAD, 0xBE, 0xEF};
+
+  std::thread sender([&]() {
+    CanFrame frame;
+    frame.set_can_id(0x321);
+    frame.set_len(static_cast<unsigned char>(payload.size()));
+    std::array<unsigned char, CAN_MAX_DLC> data{};
+    for (size_t i = 0; i < payload.size(); ++i) {
+      data[i] = payload[i];
+    }
+    frame.set_data(data);
+    REQUIRE_FALSE(adapter.send(frame).has_value());
+  });
+
+  const size_t expected_total = 11 + 1 + 2 + 2 + payload.size();
+  auto bytes = server.collect(expected_total, std::chrono::milliseconds(500));
+  sender.join();
+  adapter.closeSocket();
+
+  AxiomaticFrameParser parser;
+  parser.append(bytes.data(), bytes.size());
+  auto frame = parser.tryParseFrame();
+  REQUIRE(frame.has_value());
+  REQUIRE(frame->get_id() == 0x321u);
+  REQUIRE(static_cast<size_t>(frame->get_len()) == payload.size());
+  auto got = frame->get_data();
+  for (size_t i = 0; i < payload.size(); ++i) {
+    REQUIRE(got[i] == payload[i]);
+  }
+}


### PR DESCRIPTION
# Merge from zeerek/bugfix-axiomatic-flips-error-logic to main

## Description

ECU flashing through the Axiomatic CAN-to-Ethernet adapter has been failing intermittently, while the equivalent flash via Kvaser SocketCAN is reliable. A code audit traced the asymmetry to the TCP transport layer: the adapter was treating the byte stream as one-CAN-frame-per-read and only understood the deprecated "CAN Stream" message type, so under bursty flash traffic frames were being lost three different ways (coalesced reads, heartbeat-induced desync, packed multi-frame messages). This MR closes all eight audit findings across three phases — a quick correctness pass, a protocol-correct streaming parser rewrite, and a concurrency/throughput refactor onto a persistent `io_context` with a strand. Public API is unchanged for existing consumers (the new `verbose` argument on `AxiomaticAdapter` is defaulted). See [CLAUDE_PLAN_AND_RESOLUTIONS.md](CLAUDE_PLAN_AND_RESOLUTIONS.md) for the full design doc and finding-by-finding status.

## Highlighted Changes

[axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp](axiomatic_adapter/include/axiomatic_adapter/axiomatic_frame_parser.hpp)

- New stateful parser class for the Axiomatic byte stream — owns a persistent buffer plus a pending-frames queue.
- 6-byte `SYNC_PREFIX` (was a wrong 7-byte "header" that included Message ID), plus explicit `MSG_ID_*` constants for the four known message types.
- Diagnostic counters (`heartbeats_seen`, `notification_frames_skipped`, `dropped_bytes`, etc.) and a `set_verbose()` switch.

[axiomatic_adapter/src/axiomatic_frame_parser.cpp](axiomatic_adapter/src/axiomatic_frame_parser.cpp)

- `tryParseFrame()` walks the protocol envelope using the Message Data Length at bytes 9-10 — the canonical framing field — and dispatches on Message ID; heartbeats / status / FD / unknown are consumed and counted, never raised as errors.
- `decodeCanStreamBody()` iterates packed CAN frames and skips Notification frames inside a single CAN Stream message, draining everything into the internal queue so the existing one-frame-per-call API still works.
- Verbose mode emits a one-line `std::cout` per non-CAN event.

[axiomatic_adapter/src/axiomatic_adapter.cpp](axiomatic_adapter/src/axiomatic_adapter.cpp)

- `send()` now writes exactly `frame_data_length` payload bytes — declared `message_length` and the actual wire payload finally agree for any DLC.
- Persistent `io_context` with `executor_work_guard` runs on a dedicated worker thread for the adapter's lifetime; per-call `restart()/run()` is gone.
- `boost::asio::strand` serializes every socket op; `send()` and `receive()` post async work and block on `std::promise`/`std::future` — public sync signatures unchanged.
- Reception is a self-rescheduling `async_receive` chain posted onto the strand; `startReceptionThread()` no longer spawns a thread, `joinReceptionThread()` posts `tcp_socket_.cancel()` and waits for the chain to drain.
- `TCP_NODELAY` set immediately after a successful connect.
- Parser access mutex-guarded between the io thread and any sync `receive()` caller.

[axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp](axiomatic_adapter/include/axiomatic_adapter/axiomatic_adapter.hpp)

- `DEFAULT_SOCKET_RECEIVE_TIMEOUT_MS` lowered from 100 ms → 20 ms now that the receive loop is async and the timeout only bounds the sync polling API.
- New defaulted `bool verbose = false` constructor argument; no break for existing callers.

[axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp](axiomatic_adapter/src/axiomatic_socketcan_bridge.cpp)

- Forwards the bridge's `-v` flag into the `AxiomaticAdapter` constructor so `ros2 run axiomatic_adapter axiomatic_socketcan_bridge ... -v` flips parser verbosity too.

[axiomatic_adapter/test/axiomatic_frame_parser_test.cpp](axiomatic_adapter/test/axiomatic_frame_parser_test.cpp)

- New file: 19 unit tests covering single/coalesced/split CAN frames, packed multi-frame CAN Stream messages, mixed CAN+Notification bodies, heartbeats alone and coalesced with CAN traffic, status responses, CAN FD frames, unknown message IDs, garbage-prefix resync, header straddle, DLC 0/8 edges, and a 64-message stress.

[axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp](axiomatic_adapter/test/axiomatic_send_wire_format_test.cpp)

- New file: 4 loopback tests asserting `send()` produces a wire-correct CAN Stream message for DLC 0 / 4 / 8 and round-trips cleanly through the parser. No hardware required.

[axiomatic_adapter/test/axiomatic_concurrent_io_test.cpp](axiomatic_adapter/test/axiomatic_concurrent_io_test.cpp)

- New file: localhost peer that simultaneously consumes our outbound traffic and emits inbound CAN Stream messages while one thread hammers `send()` and the reception chain delivers frames via callback. Validates the strand serialization end-to-end.

[axiomatic_adapter/CMakeLists.txt](axiomatic_adapter/CMakeLists.txt)

- Adds `axiomatic_frame_parser.cpp` to the shared library, plus three no-hardware test executables.
- Each test compiles the adapter/parser sources directly so it does not depend on `libaxiomatic_adapter.so` at runtime — avoids the symbol-lookup race against an older `/opt/polymath/axiomatic_adapter` install on `LD_LIBRARY_PATH`.

[axiomatic_adapter/test/axiomatic_adapter_test.cpp](axiomatic_adapter/test/axiomatic_adapter_test.cpp)

- Removed the stale `// NOTE: the first run may fail` comment — that symptom was caused by the absent TCP stream framer and is fixed by this MR.

[CLAUDE_PLAN_AND_RESOLUTIONS.md](CLAUDE_PLAN_AND_RESOLUTIONS.md)

- New file: full design doc, finding-by-finding resolution table, and verification status.

## Test Plan

**Automated (added in this MR, no hardware required):** 25 Catch2 cases / 273 assertions across `test_axiomatic_frame_parser`, `test_axiomatic_send_wire_format`, and `test_axiomatic_concurrent_io`. Build with `colcon build --merge-install --packages-select axiomatic_adapter --cmake-args -DBUILD_TESTING=ON` and run with `colcon test --merge-install --packages-select axiomatic_adapter`. All passing locally.

**Manual (still owed before sign-off):**

- Re-run the existing hardware Catch2 suite against the Axiomatic device at `192.168.0.34:4000` and confirm the previously flaky "first read" no longer fails.
- Capture a raw TCP stream from the converter for ~30 s while idle and feed those bytes through the parser via the unit-test harness — expect zero CAN frames returned, `heartbeats_seen() ≈ 30`, `dropped_bytes() == 0`.
- End-to-end ECU flash through the bridge — should succeed without retries.
- Latency probe: a single `send()` → `receive()` round trip should drop from the previous ~40 ms (first-frame Nagle) to sub-millisecond.
- Optional but recommended: rebuild with `-fsanitize=thread` and run `test_axiomatic_concurrent_io` for the formal TSAN sign-off on the Phase 3 strand refactor.

## Pre-Merge Tasks

- [ ] Has the Merge Description been filled out accurately?
- [ ] Have you written tests?
- [ ] Have you created issues from any TODOS or comments?
- [ ] Have you posted in [#code_reviews](https://polymath-robotics.slack.com/archives/C070ST7V40G)

## Changes

- 283ef78 Result should only show when we FAIL
- 311afd6 Add a parser that handles incomplete data
- ea9ae85 Fix shared test weirdness. We will clean up later
- bc49dcc Claude did a number of fixes in order to try to synchronize tcp ip better
- ad5ca44 Add in last group of changes to use a strand and make us more reliable hopefully
